### PR TITLE
chore: Add files for code coverage HTML report

### DIFF
--- a/tests/codecoverage.ps1
+++ b/tests/codecoverage.ps1
@@ -1,0 +1,43 @@
+#Requires -Version 7.5
+
+<#
+Prerequisite tools:
+- `dotnet-coverage`
+- `dotnet-reportgenerator`
+
+Tool install commands:
+> dotnet tool install dotnet-coverage -g
+> dotnet tool install dotnet-reportgenerator-globaltool -g
+#>
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+# Build solution with Release configuration
+dotnet build ../ -c Release
+
+# Define session id (It's used as temprary directory name that generated at %Temp%)
+$sessionId = 'ZLinq'
+
+# Start code coverage collector session with background server mode.
+dotnet coverage collect --settings ./codecoverage.runsettings --session-id $sessionId --server-mode --background --nologo
+
+try
+{
+  # Run unit tests with code coverage data collection.
+  dotnet coverage connect $sessionId --nologo "dotnet test ../ -c Release --no-build"
+}
+finally
+{
+  # Shutdown codecoverage session
+  dotnet coverage shutdown $sessionId --nologo
+}
+
+# Run dotnet ReportGenerator
+$targetDir = 'TestResults/CoverageReports'
+reportgenerator -reports:TestResults/coverage.cobertura.xml -targetdir:$targetDir -reporttypes:Html
+
+# Show generated HTML report file path as clickable link. 
+$reportPath = Resolve-Path './TestResults/CoverageReports/index.html'
+Write-Host "CodeCoverage report file generated: `e]8;;${reportPath}`e\${reportPath}`e]8;;`e\"

--- a/tests/codecoverage.runsettings
+++ b/tests/codecoverage.runsettings
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <!-- Available Options: https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md -->
+  <CoverageFileName>TestResults/coverage.cobertura.xml</CoverageFileName>
+  <Format>cobertura</Format>
+  <IncludeTestAssembly>false</IncludeTestAssembly>
+  <DeterministicReport>true</DeterministicReport>
+  <CollectFromChildProcesses>true</CollectFromChildProcesses>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*ZLinq.*\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <!-- Exclude tests DLLS -->
+        <ModulePath>.*Tests\.dll$</ModulePath>
+
+        <!-- Exclude third party DLLs -->
+        <ModulePath>.*Shouldly\.dll$</ModulePath>
+        <ModulePath>.*DiffEngine\.dll$</ModulePath>
+      </Exclude>
+    </ModulePaths>
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+    <Sources>
+      <Exclude>
+        <Source>.*\\[^\\]*\.g\.cs</Source>
+      </Exclude>
+    </Sources>
+    <!-- Disable following settings. Because C++ code is not contained (See: https://github.com/microsoft/codecoverage/blob/main/README.md#get-started)-->
+    <EnableStaticNativeInstrumentation>False</EnableStaticNativeInstrumentation>
+    <EnableDynamicNativeInstrumentation>False</EnableDynamicNativeInstrumentation>
+  </CodeCoverage>
+</Configuration>


### PR DESCRIPTION
This PR add custom scripts/setting files for code coverage & generate HTML report.

### How to show Code Coverage HTML Reports
The following software is required to run scripts.

- PowerShell 7.5
- .NET Global Tools
  - `dotnet-coverage`
  - `dotnet-reportgenerator`

### How to confirm code coverage HTML report.
1. Set current directory to `tests`.
2. Run `pwsh ./codecoverage.ps1`
3. Open generated HTML report file with browser.