### PR TITLE
chore: Add MSBuild settings for VS build acceleration

### DIFF
--- a/src/ZLinq.SourceGenerator/ZLinq.SourceGenerator.csproj
+++ b/src/ZLinq.SourceGenerator/ZLinq.SourceGenerator.csproj
@@ -16,6 +16,10 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="$(TargetFramework.StartsWith(`netstandard`))">
+		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<!-- https://learn.microsoft.com/en-us/visualstudio/extensibility/roslyn-version-support?view=vs-2022 -->
 		<!-- require to support SyntaxValueProvider.ForAttributeWithMetadataName(Roslyn 4.3.0, VS2022 17.3) -->

--- a/src/ZLinq.__Unity/ZLinq.__Unity.csproj
+++ b/src/ZLinq.__Unity/ZLinq.__Unity.csproj
@@ -10,6 +10,10 @@
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="$(TargetFramework.StartsWith(`netstandard`))">
+		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
 	</ItemGroup>

--- a/src/ZLinq/ZLinq.csproj
+++ b/src/ZLinq/ZLinq.csproj
@@ -17,6 +17,10 @@
 		<TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="$(TargetFramework.StartsWith(`netstandard`))">
+		<ProduceReferenceAssembly>true</ProduceReferenceAssembly>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<None Include="../../Icon.png" Pack="true" PackagePath="/" />
 		<EmbeddedResource Include="..\..\LICENSE" />


### PR DESCRIPTION
When build solution with Visual Studio.
Following messages are displayed on Output Window.

> FastUpToDate: This project has enabled build acceleration, but not all referenced projects produce a reference assembly.
> Ensure projects producing the following outputs have the 'ProduceReferenceAssembly' MSBuild property set to 'true': 

So I've added `ProduceReferenceAssembly` setting for NetStandard targets.

Note: `ProduceReferenceAssembly` is [enabled by default on .NET 5 or later.](https://github.com/dotnet/project-system/blob/main/docs/build-acceleration.md#configuration)
But it's not enabled on NetStandard2.0/2.1 for backward compatibility reason.
