### PR TITLE
chore: Add support for multiple target frameworks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -17,4 +17,8 @@
         <AssemblyOriginatorKeyFile Condition="EXISTS('./../../../../../../opensource.snk')">../../../../../../opensource.snk</AssemblyOriginatorKeyFile>
     </PropertyGroup>
 
+    <PropertyGroup>
+      <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+    </PropertyGroup>
+
 </Project>

--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -2,11 +2,19 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <IsPackable>false</IsPackable>
+
+    <!-- CS8002: Referenced assembly does not have a strong name.-->
+    <NoWarn>$(NoWarn);CS8002</NoWarn>
+  </PropertyGroup>
+
+  <!-- Add .NET 10 support when running build inside Visual Studio Preview-->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != '' AND $(VisualStudioDir.Contains('Preview'))">
+    <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sandbox/Benchmark/Benchmarks/SimdAny.cs
+++ b/sandbox/Benchmark/Benchmarks/SimdAny.cs
@@ -121,7 +121,11 @@ public class SimdAny
         if (Vector.IsHardwareAccelerated && span.Length >= Vector<T>.Count)
         {
             ref var to = ref Unsafe.Subtract(ref end, Vector<T>.Count);
+#if NET9_0_OR_GREATER
             var state = Vector.Create(9800);
+#else
+            var state = new Vector<int>(9800);
+#endif
             do
             {
                 var data = Vector.LoadUnsafe(ref current);

--- a/src/ZLinq/ZLinq.csproj
+++ b/src/ZLinq/ZLinq.csproj
@@ -14,6 +14,11 @@
     <Description>Zero allocation LINQ with Span and LINQ to SIMD, LINQ to Tree (FileSystem, Json, GameObject, etc.) for all .NET platforms and Unity.</Description>
   </PropertyGroup>
 
+  <!-- Add .NET 10 support when running build inside Visual Studio Preview-->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != '' AND $(VisualStudioDir.Contains('Preview'))">
+    <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
+  </PropertyGroup>
+
   <PropertyGroup Condition="$(TargetFramework.StartsWith(`netstandard`))">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>

--- a/tests/ZLinq.Tests/Linq/CountByTest.cs
+++ b/tests/ZLinq.Tests/Linq/CountByTest.cs
@@ -12,7 +12,7 @@ public class CountByTest
             [true] = 3,   // Count of odd numbers: 1, 3, 5
             [false] = 3   // Count of even numbers: 2, 4, 6
         };
-        Enumerable.Range(1, 10).Index();
+
         // Act
         var actual = source.AsValueEnumerable()
                           .CountBy(x => x % 2 == 1)   // Key selector: odd/even

--- a/tests/ZLinq.Tests/ZLinq.Tests.csproj
+++ b/tests/ZLinq.Tests/ZLinq.Tests.csproj
@@ -4,8 +4,7 @@
     <RootNamespace>ZLinq.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <!--<TargetFrameworks>net8.0;net9.0</TargetFrameworks>-->
-    <TargetFrameworks>net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
 
@@ -13,6 +12,11 @@
     <OutputType>Exe</OutputType>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+  </PropertyGroup>
+
+  <!-- Add .NET 10 support when running build inside Visual Studio Preview-->
+  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != '' AND $(VisualStudioDir.Contains('Preview'))">
+    <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Currently tests/benchmarks project is targetting .NET 9 only.
This PR add support for .NET8, and .NET 10 (Currently preview.2)

Note: .NET 10 support is added when using Visual Studio **Preview** version only.
I'll not affect other build environment.

Additionally, following changes included.
- Add settings to suppress message when using preview version of .NET SDK
- Suppress CS8002 warnings on benchmark project
- Fix test/benchmark code that can't build with .NET 8