### PR TITLE
chore: Add .NET 6 target for netstandard2.1 tests & update xUnit.v3 package version to 2.0.0

### DIFF
--- a/tests/ZLinq.Tests/Linq/ChunkTest.cs
+++ b/tests/ZLinq.Tests/Linq/ChunkTest.cs
@@ -57,8 +57,11 @@ public class ChunkTest
             var enumerable = xs.AsValueEnumerable().Chunk(3);
 
             var e1 = enumerable;
+
+#if NET8_0_OR_GREATER
             e1.TryGetNonEnumeratedCount(out var nonEnumeratedCount).ShouldBe(true);
             nonEnumeratedCount.ShouldBe(2);
+#endif
 
             var e2 = enumerable;
             e2.TryGetSpan(out var span).ShouldBe(false);

--- a/tests/ZLinq.Tests/Linq/OrderByTest.cs
+++ b/tests/ZLinq.Tests/Linq/OrderByTest.cs
@@ -77,7 +77,11 @@ public class OrderByTest
             (x % 3).CompareTo(y % 3));
 
         var ordered = xs.AsValueEnumerable().Order(customComparer);
+#if NET8_0_OR_GREATER
         var expected = xs.Order(customComparer);
+#else
+        var expected = xs.OrderBy(x=> x, customComparer);
+#endif
 
         ordered.ToArray().ShouldBe(expected.ToArray());
     }

--- a/tests/ZLinq.Tests/ZLinq.Tests.csproj
+++ b/tests/ZLinq.Tests/ZLinq.Tests.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>ZLinq.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
 
@@ -19,16 +19,16 @@
     <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
   </PropertyGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="xunit.v3" Version="1.1.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
+  </ItemGroup>
 
-    <!-- Some environments still neds this... -->
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="xunit.v3" Version="2.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR contains following changes
- Add `net6.0` to TargetFrameworks. It's used for `netstandard2.1` tests.
- Fix some tests that failed on `net6.0`
- Update xUnit.v3 package to `2.0.0`.  
   ` net6.0` support is dropped from `2.0.0`. So need to add conditional `PackageReference`. 
- Drop VSTest related package references.  
      `,slnx` supported VS versions also supports `Microsoft.Testing.Platform` based tests.
