### PR TITLE
chore: Add codecov coverage settings

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+comment: false
+github_checks:
+  annotations: false

--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -14,9 +14,70 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]    
+        os: [ubuntu-latest, windows-latest]
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - run: dotnet build -c Release
       - run: dotnet test -c Release --no-build
+
+  check-codecov-token:
+    runs-on: ubuntu-latest
+    outputs:
+      run_codecoverage: ${{ steps.check-token.outputs.token_exists }}
+    steps:
+      - id: check-token
+        shell: pwsh
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: |
+          if(![string]::IsNullOrEmpty($env:CODECOV_TOKEN))
+          {
+            echo "token_exists=true"  >> $env:GITHUB_OUTPUT
+          }
+          else
+          {
+            echo "token_exists=false" >> $env:GITHUB_OUTPUT
+          }
+
+  code-coverage:
+    if: ${{ needs.check-codecov-token.outputs.run_codecoverage == 'true' }} # secrets can't referenced in `if` so it needs separate job.
+    needs: check-codecov-token
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: Cysharp/Actions/.github/actions/checkout@main
+      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+      - run: dotnet build -c Release
+
+      - name: Enable diagnostics (It's disabled by `Cysharp/Actions/.github/actions/setup-dotnet`)
+        run: echo "COMPlus_EnableDiagnostics=1" >> $GITHUB_ENV
+
+      - name: Install `dotnet-coverage` tool
+        run: dotnet tool install -g dotnet-coverage
+
+      - name: Collect code coverage
+        shell: pwsh
+        working-directory: tests
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          $sessionId = 'ZLinq'
+
+          dotnet coverage collect --session-id $sessionId --nologo --settings codecoverage.runsettings --server-mode --background
+          try 
+          {
+            dotnet coverage connect $sessionId --nologo "dotnet test ../ -c Release --framework net9.0 --no-build"
+            
+            # TODO: Add System.Linq.Tests coverage collection.
+          }
+          finally 
+          {
+            dotnet coverage shutdown $sessionId --nologo --timeout 60000
+          }
+
+      # Upload coverage data to CodeCov
+      - uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
+        with:
+          fail_ci_if_error: false
+          files: tests/TestResults/coverage.cobertura.xml
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/tests/codecoverage.runsettings
+++ b/tests/codecoverage.runsettings
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Configuration>
+  <!-- Available Options: https://github.com/microsoft/codecoverage/blob/main/docs/configuration.md -->
+  <CoverageFileName>TestResults/coverage.cobertura.xml</CoverageFileName>
+  <Format>cobertura</Format>
+  <IncludeTestAssembly>false</IncludeTestAssembly>
+  <DeterministicReport>true</DeterministicReport>
+  <CollectFromChildProcesses>true</CollectFromChildProcesses>
+  <CodeCoverage>
+    <ModulePaths>
+      <Include>
+        <ModulePath>.*ZLinq.*\.dll$</ModulePath>
+      </Include>
+      <Exclude>
+        <!-- Exclude tests DLLs -->
+        <ModulePath>.*Tests\.dll$</ModulePath>        
+
+        <!-- Exclude third party DLLs -->
+        <ModulePath>.*xunit.v3.*\.dll$</ModulePath>
+        <ModulePath>.*Shouldly\.dll$</ModulePath>
+        <ModulePath>.*DiffEngine\.dll$</ModulePath>
+      </Exclude>
+    </ModulePaths>
+    <Attributes>
+      <Exclude>
+        <Attribute>^System\.CodeDom\.Compiler\.GeneratedCodeAttribute$</Attribute>
+      </Exclude>
+    </Attributes>
+    <Sources>
+      <Exclude>
+        <Source>.*\\[^\\]*\.g\.cs</Source>
+      </Exclude>
+    </Sources>
+    <!-- Disable following settings. Because C++ code is not contained (See: https://github.com/microsoft/codecoverage/blob/main/README.md#get-started)-->
+    <EnableStaticNativeInstrumentation>False</EnableStaticNativeInstrumentation>
+    <EnableDynamicNativeInstrumentation>False</EnableDynamicNativeInstrumentation>
+  </CodeCoverage>
+</Configuration>


### PR DESCRIPTION
This PR add code coverage related settings to generate report by using [Codecov](https://about.codecov.io/).

This PR don't affects `Cysharp/ZLinq` repository unless explicitly set `secrets.CODECOV_TOKEN` on repository.

### Sample coverage report

Following coverage report is generated by my forked repository's workflow.
https://app.codecov.io/github/filzrev/ZLinq

### What's changed in this PR

**`.github/codecov.yml`**
CodeCov setting file.
It's placed to suppress comment to PR. (To avoid delayed notifications)

**`.github/workflows/build-debug.yml`**
Modify CI workflow settings and add following jobs
- Check `secrets.CODECOV_TOKEN` existing
- Collect CodeCoverage and send report to CodeCov (It's run only when `secrets.CODECOV_TOKEN` exists)

**`tests/codecoverage.runsettings`**
Setting file for code coverage.