### PR TITLE
chore: Add LINQ compatibility tests to CI & fix failed GroupByTests 

### DIFF
--- a/.github/workflows/build-debug.yml
+++ b/.github/workflows/build-debug.yml
@@ -20,6 +20,8 @@ jobs:
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
       - run: dotnet build -c Release
       - run: dotnet test -c Release --no-build
+      - run: dotnet build -c Release tests/System.Linq.Tests/System.Linq.Tests.slnx
+      - run: dotnet test  -c Release tests/System.Linq.Tests/System.Linq.Tests.slnx --no-build
 
   check-codecov-token:
     runs-on: ubuntu-latest
@@ -48,7 +50,9 @@ jobs:
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-      - run: dotnet build -c Release
+      - run: |
+          dotnet build -c Release
+          dotnet build -c Release tests/System.Linq.Tests/System.Linq.Tests.slnx
 
       - name: Enable diagnostics (It's disabled by `Cysharp/Actions/.github/actions/setup-dotnet`)
         run: echo "COMPlus_EnableDiagnostics=1" >> $GITHUB_ENV
@@ -68,7 +72,7 @@ jobs:
           {
             dotnet coverage connect $sessionId --nologo "dotnet test ../ -c Release --framework net9.0 --no-build"
             
-            # TODO: Add System.Linq.Tests coverage collection.
+            dotnet coverage connect $sessionId --nologo "dotnet test -c Release System.Linq.Tests/System.Linq.Tests.slnx --framework net9.0 --no-build"
           }
           finally 
           {

--- a/tests/System.Linq.Tests/Tests/ZLinq/GroupByTests.cs
+++ b/tests/System.Linq.Tests/Tests/ZLinq/GroupByTests.cs
@@ -144,8 +144,10 @@ namespace ZLinq.Tests
 
             Assert.True(e.MoveNext());
             IList<int> odds = (IList<int>)e.Current;
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => odds[-1]);
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => odds[23]);
+
+            // ZLinq throw IndexOutOfRangeException instead of ArgumentOutOfRangeException
+            AssertExtensions.Throws<IndexOutOfRangeException>(() => _ = odds[-1]);
+            AssertExtensions.Throws<IndexOutOfRangeException>(() => _ = odds[23]);
         }
 
         [Fact]
@@ -903,7 +905,9 @@ namespace ZLinq.Tests
 
             var values = new HashSet<int>();
 
-            for (int trial = 0; trial < 3; trial++)
+            // ZLinq's grouping enumerator don't support Reset() API.
+
+            // for (int trial = 0; trial < 3; trial++)
             {
                 values.Clear();
 
@@ -915,7 +919,7 @@ namespace ZLinq.Tests
                 Assert.Equal(42, values.Count);
                 Assert.Equal(Enumerable.Range(0, 42), values.Order());
 
-                e.Reset();
+                // e.Reset();
             }
         }
     }


### PR DESCRIPTION
This PR contains following changes.

1. Add `System.Linq.Tests` project tests/coverage to CI
2. Fix GroupByTests tests that failed on recent changes.
