### PR TITLE
chore: Show unit tests errors on CI logs

### DIFF
--- a/tests/System.Linq.Tests/System.Linq.Tests.csproj
+++ b/tests/System.Linq.Tests/System.Linq.Tests.csproj
@@ -18,6 +18,7 @@
   <PropertyGroup>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
   <!-- Add .NET 10 support when running build inside Visual Studio Preview-->

--- a/tests/ZLinq.Tests/ZLinq.Tests.csproj
+++ b/tests/ZLinq.Tests/ZLinq.Tests.csproj
@@ -12,6 +12,7 @@
     <OutputType>Exe</OutputType>
     <UseMicrosoftTestingPlatformRunner>true</UseMicrosoftTestingPlatformRunner>
     <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
   <!-- Add .NET Framework test -->


### PR DESCRIPTION
Currently it can't confirms what's unit tests failed on CI.
Because `Microsoft.Testing.Platform` output logs to file and it's not uploaded as artifacts.

This PR add following setting to output error logs to console. 

```xml
<TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
```



