### PR TITLE
chore: add DebuggerTypeProxy for Grouping/Lookup

### DIFF
--- a/sandbox/ConsoleApp/Program.cs
+++ b/sandbox/ConsoleApp/Program.cs
@@ -41,6 +41,17 @@ var barbaz = items.AsValueEnumerable().TakeWhile(x => x < 5);
 //Console.WriteLine(foobar.JoinToString(","));
 
 
+// LINQ
+var source1 = Enumerable.Range(1, 500);
+var enumerable = source1.Where(x => x % 2 == 0);
+var group1 = source1.GroupBy(x => x % 10);
+var lookup1 = source1.ToLookup(x => x % 10);
+
+// ZLINQ
+var source2 = ValueEnumerable.Range(1, 500);
+var valuEnumerable = source2.Where(x => x % 2 == 0);
+var group2 = source2.GroupBy(x => x % 10);
+var lookup2 = source2.ToLookup(x => x % 10);
 
 return;
 

--- a/src/ZLinq/Linq/ToLookup.cs
+++ b/src/ZLinq/Linq/ToLookup.cs
@@ -313,6 +313,8 @@ namespace ZLinq.Linq
     }
 
     // .NET ILookup implements ICollection and it is public
+    [DebuggerDisplay("Count = {Count}")]
+    [DebuggerTypeProxy(typeof(LookupDebugView<,>))]
     public sealed class Lookup<TKey, TElement> : ILookup<TKey, TElement>, ICollection<IGrouping<TKey, TElement>>, IReadOnlyCollection<IGrouping<TKey, TElement>>
     {
         internal static readonly Lookup<TKey, TElement> Empty = new Lookup<TKey, TElement>();
@@ -482,7 +484,8 @@ namespace ZLinq.Linq
         }
     }
 
-    [DebuggerDisplay("Key = {Key}, ({Count})")]
+    [DebuggerDisplay("Key = {Key}")]
+    [DebuggerTypeProxy(typeof(GroupingDebugView<,>))]
     internal sealed class Grouping<TKey, TElement> : IGrouping<TKey, TElement>, IList<TElement>, IReadOnlyList<TElement>
     {
         TKey key;
@@ -578,5 +581,35 @@ namespace ZLinq.Linq
         {
             throw new NotSupportedException();
         }
+    }
+   
+    internal sealed class GroupingDebugView<TKey, TElement>
+    {
+        readonly Grouping<TKey, TElement> _grouping;
+        TElement[]? _cachedValues;
+
+        public GroupingDebugView(Grouping<TKey, TElement> grouping)
+        {
+            _grouping = grouping;
+        }
+
+        public TKey Key => _grouping.Key;
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public TElement[] Values => _cachedValues ??= _grouping.ToArray();
+    }
+
+    internal sealed class LookupDebugView<TKey, TElement>
+    {
+        readonly ILookup<TKey, TElement> _lookup;
+        IGrouping<TKey, TElement>[]? _cachedGroupings;
+
+        public LookupDebugView(ILookup<TKey, TElement> lookup)
+        {
+            _lookup = lookup;
+        }
+
+        [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
+        public IGrouping<TKey, TElement>[] Groupings => _cachedGroupings ??= _lookup.ToArray();
     }
 }


### PR DESCRIPTION
This PR add `DebuggerTypeProxy` for `Grouping` and `Lookup`.

DebuggerTypeProxy behaviors can be confirmed by code that added to `sandbox/ConsoleApp/Program.cs`