### PR TITLE
chore: Add benchmarks that use dedicated optimization path by System.Linq

### DIFF
--- a/sandbox/Benchmark/Benchmarks/Net80OptimizedBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/Net80OptimizedBenchmark.cs
@@ -1,0 +1,82 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using ZLinq;
+
+namespace Benchmark;
+
+// Based on: https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8/
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class Net80OptimizedBenchmark
+{
+    int[] source = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        source = Enumerable.Range(1, 1000)
+                           .Select(_ => Random.Shared.Next(1, 1000))
+                           .ToArray();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public void SelectToList_SystemLinq()
+    {
+        _ = source.Select(i => i * 2)
+                  .ToList();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public void RepeatToList_SystemLinq()
+    {
+        _ = Enumerable.Repeat((byte)'a', 1024)
+                     .ToList();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public void RangeSelectToList_SystemLinq()
+    {
+        _ = Enumerable.Range(0, 1024)
+                      .Select(i => i * 2)
+                      .ToList();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public void SelectToList_ZLinq()
+    {
+        _ = source.Select(i => i * 2)
+                  .AsValueEnumerable()
+                  .ToList();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public void RepeatToList_ZLinq()
+    {
+        _ = Enumerable.Repeat((byte)'a', 1024)
+                      .AsValueEnumerable()
+                      .ToList();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public void RangeSelectToList_ZLinq()
+    {
+        _ = Enumerable.Range(0, 1024)
+                      .AsValueEnumerable()
+                      .Select(i => i * 2)
+                      .ToList();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public void RangeSelectToList_ZLinqOptimized()
+    {
+        _ = ValueEnumerable.Range(0, 1024)
+                           .Select(i => i * 2)
+                           .ToList();
+    }
+}

--- a/sandbox/Benchmark/Benchmarks/Net90OptimizedBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/Net90OptimizedBenchmark.cs
@@ -1,0 +1,157 @@
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using ZLinq;
+
+namespace Benchmark;
+
+// Based on: https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-9/
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class Net90OptimizedBenchmark
+{
+    int[] source = default!;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        source = Enumerable.Range(1, 1000)
+                           .Select(_ => Random.Shared.Next(1, 1000))
+                           .ToArray();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public int DistinctFirst_SystemLinq()
+    {
+        return source.Distinct()
+                     .First();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public int AppendSelectLast_SystemLinq()
+    {
+        return source.Append(42)
+                     .Select(x => x * 2)
+                     .Last();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public int RangeReverseCount_SystemLinq()
+    {
+        return source.Reverse()
+                     .Count();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public int DefaultIfEmptySelectElementAt_SystemLinq()
+    {
+        return source.DefaultIfEmpty()
+                     .Select(i => i * 2)
+                     .ElementAt(999);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public int ListSkipTakeElementAt_SystemLinq()
+    {
+        return source.Skip(500)
+                     .Take(100)
+                     .ElementAt(99);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public int RangeUnionFirst_SystemLinq()
+    {
+        return source.Union(Enumerable.Range(500, 1000))
+                     .First();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public int SelectWhereSelectSum_SystemLinq()
+    {
+        return source.Select(i => i * 2)
+                     .Where(i => i % 2 == 0)
+                     .Select(i => i * 2)
+                     .Sum();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public int ZDistinctFirst_ZLinq()
+    {
+        return source.AsValueEnumerable()
+                     .Distinct()
+                     .First();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public int ZAppendSelectLast_ZLinq()
+    {
+        return source.AsValueEnumerable()
+                     .Append(42)
+                     .Select(x => x * 2)
+                     .Last();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public int ZRangeReverseCount_ZLinq()
+    {
+        return source.AsValueEnumerable()
+                     .Reverse()
+                     .Count();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public int ZDefaultIfEmptySelectElementAt_ZLinq()
+    {
+        return source.AsValueEnumerable()
+                     .DefaultIfEmpty()
+                     .Select(i => i * 2)
+                     .ElementAt(999);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public int ZListSkipTakeElementAt_ZLinq()
+    {
+        return source.AsValueEnumerable()
+                     .Skip(500)
+                     .Take(100)
+                     .ElementAt(99);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public int ZRangeUnionFirst_ZLinq()
+    {
+        return source.AsValueEnumerable()
+                     .Union(Enumerable.Range(500, 1000))
+                     .First();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public int ZRangeUnionFirst_ZLinqOptimized()
+    {
+        return source.AsValueEnumerable()
+                     .Union(ValueEnumerable.Range(500, 1000))
+                     .First();
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public int ZSelectWhereSelectSum_ZLinq()
+    {
+        return source.AsValueEnumerable()
+                     .Select(i => i * 2)
+                     .Where(i => i % 2 == 0)
+                     .Select(i => i * 2).Sum();
+    }
+}


### PR DESCRIPTION
This PR add LINQ benchmarks that described at following URLs.
- https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-8
- https://devblogs.microsoft.com/dotnet/performance-improvements-in-net-9

From benchmark results.
Some dedicated optimization path seems to be used by System.Linq.

**Results of Net80OptimizedBenchmark**
| Method                           | Mean        | Error     | StdDev    | Gen0   | Allocated |
|--------------------------------- |------------:|----------:|----------:|-------:|----------:|
| SelectToList_SystemLinq          |   811.08 ns | 426.81 ns | 23.395 ns | 0.9804 |   4.01 KB |
| RepeatToList_SystemLinq          |    58.63 ns |  77.59 ns |  4.253 ns | 0.2658 |   1.09 KB |
| RangeSelectToList_SystemLinq     |   775.82 ns | 715.34 ns | 39.210 ns | 1.0128 |   4.14 KB |
|                                  |             |           |           |        |           |
| SelectToList_ZLinq               | 2,997.08 ns | 516.19 ns | 28.294 ns | 0.9804 |   4.01 KB |
| RepeatToList_ZLinq               | 2,452.75 ns | 354.05 ns | 19.407 ns | 0.2632 |   1.09 KB |
| RangeSelectToList_ZLinq          | 2,772.41 ns | 295.97 ns | 16.223 ns | 0.9995 |   4.09 KB |
| RangeSelectToList_ZLinqOptimized | 2,471.54 ns | 180.95 ns |  9.918 ns | 0.9918 |   4.05 KB |

**Results of Net90OptimizedBenchmark**
| Method                                   | Mean         | Error       | StdDev     | Gen0   | Allocated |
|----------------------------------------- |-------------:|------------:|-----------:|-------:|----------:|
| DistinctFirst_SystemLinq                 |    16.095 ns |  14.5952 ns |  0.8000 ns | 0.0153 |      64 B |
| AppendSelectLast_SystemLinq              |    29.764 ns |  24.8648 ns |  1.3629 ns | 0.0268 |     112 B |
| RangeReverseCount_SystemLinq             |    18.115 ns |   6.8303 ns |  0.3744 ns | 0.0115 |      48 B |
| DefaultIfEmptySelectElementAt_SystemLinq |    15.344 ns |   7.2214 ns |  0.3958 ns | 0.0115 |      48 B |
| ListSkipTakeElementAt_SystemLinq         |    32.375 ns |  18.4966 ns |  1.0139 ns | 0.0229 |      96 B |
| RangeUnionFirst_SystemLinq               |    32.644 ns |  25.5304 ns |  1.3994 ns | 0.0268 |     112 B |
| SelectWhereSelectSum_SystemLinq          | 3,282.915 ns |  47.7935 ns |  2.6197 ns | 0.0381 |     168 B |
|                                          |              |             |            |        |           |
| ZDistinctFirst_ZLinq                     |    43.233 ns |   8.5557 ns |  0.4690 ns | 0.0134 |      56 B |
| ZAppendSelectLast_ZLinq                  | 2,141.056 ns | 282.5460 ns | 15.4873 ns |      - |         - |
| ZRangeReverseCount_ZLinq                 |     8.600 ns |   0.1929 ns |  0.0106 ns |      - |         - |
| ZDefaultIfEmptySelectElementAt_ZLinq     |    12.830 ns |  12.8783 ns |  0.7059 ns |      - |         - |
| ZListSkipTakeElementAt_ZLinq             |    20.908 ns |   4.7675 ns |  0.2613 ns |      - |         - |
| ZRangeUnionFirst_ZLinq                   |    55.177 ns |  17.0159 ns |  0.9327 ns | 0.0229 |      96 B |
| ZRangeUnionFirst_ZLinqOptimized          |    47.520 ns |  10.3418 ns |  0.5669 ns | 0.0134 |      56 B |
| ZSelectWhereSelectSum_ZLinq              | 1,303.368 ns |  84.3879 ns |  4.6256 ns |      - |         - |