### PR TITLE
chore: fix Index() issue for enumerable that length is int.MaxValue

### DIFF
--- a/src/ZLinq/Linq/Index.cs
+++ b/src/ZLinq/Linq/Index.cs
@@ -29,7 +29,7 @@ namespace ZLinq.Linq
 #endif
     {
         TEnumerator source = source;
-        int index;
+        int index = -1;
 
         public bool TryGetNonEnumeratedCount(out int count)
         {
@@ -66,8 +66,8 @@ namespace ZLinq.Linq
         {
             if (source.TryGetNext(out var value))
             {
-                current = (index, value);
                 checked { index++; }
+                current = (index, value);
                 return true;
             }
 


### PR DESCRIPTION
This PR fix issue that following **stress test** failed.
https://github.com/Cysharp/ZLinq/blob/057eafb7e46a477bf24e077daa45e142bf8f1292/tests/System.Linq.Tests/Tests/ZLinq/IndexTests.cs#L39-L51

It need to change base index to `-1` to support enumerable that length is int.MaxLength.

**System.Linq implementation**
https://github.com/dotnet/runtime/blob/a2e1d21bb4faf914363968b812c990329ba92d8e/src/libraries/System.Linq/src/System/Linq/Index.cs#L30-L42

