### PR TITLE
chore: exclude CS9074 warning from WaningAsError

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,8 @@
     <!-- NuGet Missing Compiler Flags -->
     <Features>strict</Features>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <WarningsAsErrors />
+    <!-- CS9074: The 'scoped' modifier of parameter 'span' doesn't match overridden or implemented member.-->
+    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS9074</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
When build solution with .NET 10 SDK Preview2.
Following warnings are reported and handled as error.

> The 'scoped' modifier of parameter 'span' doesn't match overridden or implemented member.

- https://github.com/Cysharp/ZLinq/blob/057eafb7e46a477bf24e077daa45e142bf8f1292/src/ZLinq.Unity/Assets/ZLinq.Unity/Runtime/OfComponent.cs#L27
- https://github.com/Cysharp/ZLinq/blob/057eafb7e46a477bf24e077daa45e142bf8f1292/src/ZLinq.Unity/Assets/ZLinq.Unity/Runtime/OfComponent.cs#L78
