### PR TITLE
chore: Add tests to increase code coverage rate

### DIFF
--- a/tests/ZLinq.Tests/Linq/AsValueEnumerableTest.cs
+++ b/tests/ZLinq.Tests/Linq/AsValueEnumerableTest.cs
@@ -334,17 +334,57 @@ namespace ZLinq.Tests.Linq
         {
             // Arrange
             var source = ImmutableArray.Create(1, 2, 3, 4, 5);
-            
+
             // Act
             var result = source.AsValueEnumerable();
-            
+
             // Assert
             result.TryGetNonEnumeratedCount(out var count).ShouldBeTrue();
             count.ShouldBe(source.Length);
-            
+
             result.TryGetSpan(out var span).ShouldBeTrue();
             span.ToArray().ShouldBe(source.ToArray());
-            
+
+            var resultArray = result.ToArray();
+            resultArray.ShouldBe(source.ToArray());
+        }
+#endif
+
+#if NET9_0_OR_GREATER
+        [Fact]
+        public void FromSpan_BasicFunctionality()
+        {
+            // Arrange
+            Span<int> source = [1, 2, 3, 4, 5];
+
+            // Act
+            var result = source.AsValueEnumerable();
+
+            // Assert
+            result.TryGetNonEnumeratedCount(out var count).ShouldBeTrue();
+            count.ShouldBe(source.Length);
+
+            result.TryGetSpan(out var span).ShouldBeTrue();
+
+            var resultArray = result.ToArray();
+            resultArray.ShouldBe(source.ToArray());
+        }
+
+        [Fact]
+        public void FromReadOnlySpan_BasicFunctionality()
+        {
+            // Arrange
+            ReadOnlySpan<int> source = [1, 2, 3, 4, 5];
+
+            // Act
+            var result = source.AsValueEnumerable();
+
+            // Assert
+            result.TryGetNonEnumeratedCount(out var count).ShouldBeTrue();
+            count.ShouldBe(source.Length);
+
+            result.TryGetSpan(out var span).ShouldBeTrue();
+
             var resultArray = result.ToArray();
             resultArray.ShouldBe(source.ToArray());
         }

--- a/tests/ZLinq.Tests/Linq/EmptyTest.cs
+++ b/tests/ZLinq.Tests/Linq/EmptyTest.cs
@@ -6,6 +6,9 @@ public class Empty
     public void Standard()
     {
         ValueEnumerable.Empty<int>().Select(x => x).ToArray().ShouldBe(Enumerable.Empty<int>().ToArray());
+
+        ValueEnumerable.Empty<int>().TryGetNonEnumeratedCount(out var count).ShouldBeTrue();
+        count.ShouldBe(0);
     }
 
     [Fact]
@@ -17,5 +20,16 @@ public class Empty
             e.MoveNext();
             item.ShouldBe(e.Current);
         }
+    }
+
+    [Fact]
+    public void TryGetSpanTryCopyTo()
+    {
+        var valueEnumerable = ValueEnumerable.Empty<int>();
+
+        valueEnumerable.TryGetSpan(out var span).ShouldBeTrue();
+        span.Length.ShouldBe(0);
+
+        valueEnumerable.TryCopyTo([], 0).ShouldBeTrue();
     }
 }

--- a/tests/ZLinq.Tests/Linq/FromImmutableArrayTest.cs
+++ b/tests/ZLinq.Tests/Linq/FromImmutableArrayTest.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Immutable;
+
+namespace ZLinq.Tests.Linq;
+
+#if NET8_0_OR_GREATER
+
+#pragma warning disable CS8500 // CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type 
+
+public class FromImmutableArrayTest
+{
+    [Fact]
+    public void TryGetNext()
+    {
+        ImmutableArray<int> source = [1, 2, 3, 4, 5];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        foreach (var i in valueEnumerable)
+        {
+        }
+    }
+
+    [Fact]
+    public void TryGetSpan()
+    {
+        ImmutableArray<int> source = [1, 2, 3, 4, 5];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        valueEnumerable.TryGetSpan(out var span).ShouldBeTrue();
+
+        IsSameSpan(source.AsSpan(), span).ShouldBeTrue();
+
+        // Additional tests
+#pragma warning disable IDE0300 // Simplify collection initialization
+        IsSameSpan(source.AsSpan(), new[] { 1, 2, 3, 4, 5 }.AsSpan()).ShouldBeFalse(); // AsSpan() is required. Because without AsSpan call. it seems to be optimized.
+#pragma warning restore IDE0300
+    }
+
+    [Fact]
+    public void TryGetNext_EmptyImmutableArray()
+    {
+        ImmutableArray<int> source = [];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        valueEnumerable.TryGetSpan(out var span).ShouldBeTrue();
+
+        IsSameSpan(source.AsSpan(), span).ShouldBeTrue();
+        IsSameSpan(span, ImmutableArray<int>.Empty.AsSpan()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryGetNonEnumeratedCount()
+    {
+        ImmutableArray<int> source = [1, 2, 3, 4, 5];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        // Test getting count without enumeration
+        valueEnumerable.TryGetNonEnumeratedCount(out var count1).ShouldBeTrue();
+        count1.ShouldBe(source.Length);
+    }
+
+    [Fact]
+    public void AsValueEnumerable()
+    {
+        ImmutableArray<int> source = [1, 2, 3, 4, 5];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        // Test getting count without enumeration
+        valueEnumerable.TryGetNonEnumeratedCount(out var count1).ShouldBeTrue();
+        count1.ShouldBe(source.Length);
+    }
+
+    [Fact]
+    public void Dispose_CanBeCalledMultipleTimes()
+    {
+        ImmutableArray<int> source = [1, 2, 3, 4, 5];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        // Should not throw exceptions
+        valueEnumerable.Dispose();
+        valueEnumerable.Dispose();
+        valueEnumerable.Dispose();
+    }
+
+    private static unsafe bool IsSameSpan<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual)
+        where T : unmanaged
+    {
+        var ptrExpected = Unsafe.AsPointer(ref Unsafe.AsRef(in expected.GetPinnableReference()));
+        var ptrActual = Unsafe.AsPointer(ref Unsafe.AsRef(in actual.GetPinnableReference()));
+
+        return ptrExpected == ptrActual && expected.Length == actual.Length;
+    }
+}
+#endif

--- a/tests/ZLinq.Tests/Linq/FromReadOnlySequenceTest.cs
+++ b/tests/ZLinq.Tests/Linq/FromReadOnlySequenceTest.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Buffers;
+using System.Collections.Immutable;
+
+namespace ZLinq.Tests.Linq;
+
+#if NET6_0_OR_GREATER
+
+#pragma warning disable CS8500 // CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type 
+
+public class FromReadOnlySequenceTest
+{
+    [Fact]
+    public void TryGetNext()
+    {
+        var segment1 = new TestReadOnlySegment<int>(new int[] { 1, 2, 3, 4, 5 });
+        var segment2 = segment1.Append(new int[] { 6, 7, 8, 9, 10 });
+        var source = new ReadOnlySequence<int>(segment1, 0, segment2, 5);
+        var valueEnumerable = source.AsValueEnumerable();
+
+        foreach (var i in valueEnumerable)
+        {
+        }
+    }
+
+    [Fact]
+    public void TryGetSpan()
+    {
+        ReadOnlySequence<int> source = new ReadOnlySequence<int>([1, 2, 3, 4, 5]);
+        var valueEnumerable = source.AsValueEnumerable();
+
+        valueEnumerable.TryGetSpan(out var span).ShouldBeTrue();
+
+        IsSameSpan(source.FirstSpan, span).ShouldBeTrue();
+
+        // Additional tests
+#pragma warning disable IDE0300 // Simplify collection initialization
+        IsSameSpan(source.FirstSpan, new[] { 1, 2, 3, 4, 5 }.AsSpan()).ShouldBeFalse(); // AsSpan() is required. Because without AsSpan call. it seems to be optimized.
+#pragma warning restore IDE0300
+    }
+
+    [Fact]
+    public void TryGetSpan_MultiSegment()
+    {
+        var segment1 = new TestReadOnlySegment<int>(new int[] { 1, 2, 3, 4, 5 });
+        var segment2 = segment1.Append(new int[] { 6, 7, 8, 9, 10 });
+        var source = new ReadOnlySequence<int>(segment1, 0, segment2, 5);
+        var valueEnumerable = source.AsValueEnumerable();
+
+        source.IsSingleSegment.ShouldBeFalse();
+        valueEnumerable.TryGetSpan(out var span).ShouldBeFalse();
+    }
+
+    [Fact]
+    public void TryGetNext_EmptyImmutableArray()
+    {
+        ReadOnlySequence<int> source = new ReadOnlySequence<int>([]);
+        var valueEnumerable = source.AsValueEnumerable();
+
+        valueEnumerable.TryGetSpan(out var span).ShouldBeTrue();
+
+        IsSameSpan(source.FirstSpan, span).ShouldBeTrue();
+        IsSameSpan(span, ImmutableArray<int>.Empty.AsSpan()).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryGetNonEnumeratedCount()
+    {
+        ReadOnlySequence<int> source = new ReadOnlySequence<int>([1, 2, 3, 4, 5]);
+        var valueEnumerable = source.AsValueEnumerable();
+
+        // Test getting count without enumeration
+        valueEnumerable.TryGetNonEnumeratedCount(out var count1).ShouldBeTrue();
+        ((long)count1).ShouldBe(source.Length);
+    }
+
+    [Fact(Skip = "Requires CPU/Memory resources to execute.")]
+    public void TryGetNonEnumeratedCount_Over_ArrayMaxLength()
+    {
+        ReadOnlySequence<int> source = new ReadOnlySequence<int>(Enumerable.Range(1, int.MaxValue).ToArray());
+        var valueEnumerable = source.AsValueEnumerable();
+
+        valueEnumerable.TryGetNonEnumeratedCount(out var count).ShouldBeFalse();
+        count.ShouldBe(0);
+    }
+
+    [Fact]
+    public void AsValueEnumerable()
+    {
+        ReadOnlySequence<int> source = new ReadOnlySequence<int>([1, 2, 3, 4, 5]);
+        var valueEnumerable = source.AsValueEnumerable();
+
+        // Test getting count without enumeration
+        valueEnumerable.TryGetNonEnumeratedCount(out var count1).ShouldBeTrue();
+        ((long)count1).ShouldBe(source.Length);
+    }
+
+    [Fact]
+    public void TryCopyTo_SingleSegment()
+    {
+        ReadOnlySequence<int> source = new ReadOnlySequence<int>([1, 2, 3, 4, 5]);
+        var valueEnumerable = source.AsValueEnumerable();
+
+        var destination = new int[5];
+        valueEnumerable.TryCopyTo(destination, 0).ShouldBeTrue();
+        destination.ShouldBe([1, 2, 3, 4, 5]);
+        source.IsSingleSegment.ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryCopyTo_MultiSegment()
+    {
+        var segment1 = new TestReadOnlySegment<int>(new int[] { 1, 2, 3, 4, 5 });
+        var segment2 = segment1.Append(new int[] { 6, 7, 8, 9, 10 });
+        var source = new ReadOnlySequence<int>(segment1, 0, segment2, 5);
+        var valueEnumerable = source.AsValueEnumerable();
+
+        var destination = new int[10];
+        valueEnumerable.TryCopyTo(destination).ShouldBeTrue();
+        destination.ShouldBe([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+        source.IsSingleSegment.ShouldBeFalse();
+    }
+
+    [Fact]
+    public void Dispose_CanBeCalledMultipleTimes()
+    {
+        ReadOnlySequence<int> source = new ReadOnlySequence<int>([1, 2, 3, 4, 5]);
+        var valueEnumerable = source.AsValueEnumerable();
+
+        // Should not throw exceptions
+        valueEnumerable.Dispose();
+        valueEnumerable.Dispose();
+        valueEnumerable.Dispose();
+    }
+
+    private static unsafe bool IsSameSpan<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual)
+        where T : unmanaged
+    {
+        var ptrExpected = Unsafe.AsPointer(ref Unsafe.AsRef(in expected.GetPinnableReference()));
+        var ptrActual = Unsafe.AsPointer(ref Unsafe.AsRef(in actual.GetPinnableReference()));
+
+        return ptrExpected == ptrActual && expected.Length == actual.Length;
+    }
+
+    private class TestReadOnlySegment<T> : ReadOnlySequenceSegment<T>
+    {
+        public TestReadOnlySegment(ReadOnlyMemory<T> memory)
+        {
+            Memory = memory;
+        }
+
+        public TestReadOnlySegment<T> Append(ReadOnlyMemory<T> memory)
+        {
+            var segment = new TestReadOnlySegment<T>(memory)
+            {
+                RunningIndex = RunningIndex + Memory.Length
+            };
+
+            Next = segment;
+            return segment;
+        }
+    }
+}
+#endif

--- a/tests/ZLinq.Tests/Linq/FromSpanTest.cs
+++ b/tests/ZLinq.Tests/Linq/FromSpanTest.cs
@@ -1,0 +1,84 @@
+﻿using System;
+
+namespace ZLinq.Tests.Linq;
+
+#if NET9_0_OR_GREATER
+
+#pragma warning disable CS8500 // CS8500: This takes the address of, gets the size of, or declares a pointer to a managed type 
+
+public class FromSpanTest
+{
+    [Fact]
+    public void TryGetNext()
+    {
+        ReadOnlySpan<int> source = [1, 2, 3, 4, 5];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        foreach (var i in valueEnumerable)
+        {
+        }
+    }
+
+    [Fact]
+    public void TryGetSpan()
+    {
+        ReadOnlySpan<int> source = [1, 2, 3, 4, 5];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        valueEnumerable.TryGetSpan(out var span).ShouldBeTrue();
+
+        IsSameSpan(source, span).ShouldBeTrue();
+
+        // Additional tests
+
+        IsSameSpan(source, [1, 2, 3, 4, 5]).ShouldBeTrue();
+
+#pragma warning disable IDE0300 // Simplify collection initialization
+        IsSameSpan(source, new[] { 1, 2, 3, 4, 5 }.AsSpan()).ShouldBeFalse(); // AsSpan() is required. Because without AsSpan call. it seems to be optimized.
+#pragma warning restore IDE0300
+    }
+
+    [Fact]
+    public void TryGetNext_EmptySpan()
+    {
+        ReadOnlySpan<int> source = [];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        valueEnumerable.TryGetSpan(out var span).ShouldBeTrue();
+
+        IsSameSpan(source, span).ShouldBeTrue();
+    }
+
+    [Fact]
+    public void TryGetNonEnumeratedCount()
+    {
+        ReadOnlySpan<int> source = [1, 2, 3, 4, 5];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        // Test getting count without enumeration
+        valueEnumerable.TryGetNonEnumeratedCount(out var count1).ShouldBeTrue();
+        count1.ShouldBe(source.Length);
+    }
+
+    [Fact]
+    public void Dispose_CanBeCalledMultipleTimes()
+    {
+        ReadOnlySpan<int> source = [1, 2, 3, 4, 5];
+        var valueEnumerable = source.AsValueEnumerable();
+
+        // Should not throw exceptions
+        valueEnumerable.Dispose();
+        valueEnumerable.Dispose();
+        valueEnumerable.Dispose();
+    }
+
+    private static unsafe bool IsSameSpan<T>(ReadOnlySpan<T> expected, ReadOnlySpan<T> actual)
+        where T : unmanaged
+    {
+        var ptrExpected = Unsafe.AsPointer(ref Unsafe.AsRef(in expected.GetPinnableReference()));
+        var ptrActual = Unsafe.AsPointer(ref Unsafe.AsRef(in actual.GetPinnableReference()));
+
+        return ptrExpected == ptrActual && expected.Length == actual.Length;
+    }
+}
+#endif

--- a/tests/ZLinq.Tests/ZLinq.Tests.csproj
+++ b/tests/ZLinq.Tests/ZLinq.Tests.csproj
@@ -7,6 +7,7 @@
     <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>13</LangVersion>
     <IsPackable>false</IsPackable>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Microsoft.Testing.Platform Support -->
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
This PR add unit tests for following APIs.
- FromEmpty
- FromImmutableArray
- FromReadOnlySequenceTest
- FromSpanTest

By these changes. Code coverage rate increased from 82.91% to 83.86%

Additionally, I've added `AllowUnsafeBlocks` to `ZLinq.Tests.csproj`.
It's required to check `Span` equity.