### PR TITLE
chore: Add custom code path for .NET 10 that use  `Span.Contains` API 

### DIFF
--- a/src/ZLinq/Linq/Contains.cs
+++ b/src/ZLinq/Linq/Contains.cs
@@ -48,8 +48,10 @@ namespace ZLinq
             {
                 if (enumerator.TryGetSpan(out var span))
                 {
-                    // NOTE: .NET 10 can call span.Contains with comparer so no needs this hack.
-#if NET8_0_OR_GREATER
+
+#if NET10_0_OR_GREATER
+                    return span.Contains(value);
+#elif NET8_0_OR_GREATER
                     return InvokeSpanContains(span, value);
 #else
                     foreach (var item in span)
@@ -114,7 +116,7 @@ namespace ZLinq
             }
         }
 
-#if NET8_0_OR_GREATER
+#if NET8_0_OR_GREATER && (NET8_0 || NET9_0)
 
         // Hack to avoid where constraints of MemoryExtensions.Contains.
         // .NET 10 removed it so no needs this hack. https://github.com/dotnet/runtime/pull/110197

--- a/src/ZLinq/Simd/Vectorizable.cs
+++ b/src/ZLinq/Simd/Vectorizable.cs
@@ -107,7 +107,11 @@ public readonly ref partial struct Vectorizable<T>(ReadOnlySpan<T> source)
 
     public bool Contains(T value)
     {
+#if NET10_0_OR_GREATER
+        return source.Contains(value);
+#else
         return InvokeSpanContains(source, value);
+#endif
     }
 
     public bool SequenceEqual(ReadOnlySpan<T> second)


### PR DESCRIPTION
This PR add custom code path for .NET 10 that use `Span.Contains` API.

Currently CI don't run .NET 10 tests.
So I've confirmed it works as expected on local environment.

