### PR TITLE
chore: Fair benchmarking of VectorizableUpdate.

### DIFF
--- a/sandbox/Benchmark/Benchmarks/VectorizableUpdate.cs
+++ b/sandbox/Benchmark/Benchmarks/VectorizableUpdate.cs
@@ -22,6 +22,7 @@ public class VectorizableUpdate
     [Benchmark]
     public int[] For()
     {
+        var source = this.source;
         for (int i = 0; i < source.Length; i++)
         {
             source[i] = source[i] * 10;


### PR DESCRIPTION
The benchmarking of VectorizableUpdate.For was not fair.
```
BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.3476)
13th Gen Intel Core i7-13700F, 1 CPU, 24 logical and 16 physical cores
.NET SDK 9.0.200
  [Host]            : .NET 9.0.3 (9.0.325.11113), X64 RyuJIT AVX2
  Default(.NET 9.0) : .NET 9.0.3 (9.0.325.11113), X64 RyuJIT AVX2

Job=Default(.NET 9.0)  PowerPlanMode=00000000-0000-0000-0000-000000000000  Toolchain=.NET 9.0  
IterationCount=3  LaunchCount=1  RunStrategy=Throughput  
WarmupCount=3  

| Method           | N     | Mean       | Error     | StdDev   | Allocated |
|----------------- |------ |-----------:|----------:|---------:|----------:|
| For              | 10000 | 3,912.5 ns | 360.14 ns | 19.74 ns |         - |
| 'For (PR)'       | 10000 | 2,768.7 ns | 190.00 ns | 10.41 ns |         - |
| VectorizedUpdate | 10000 |   660.7 ns |  29.35 ns |  1.61 ns |         - |
| InlineSimd       | 10000 |   306.8 ns |  10.58 ns |  0.58 ns |         - |
```