### PR TITLE
Fix Append and Prepend

### DIFF
--- a/src/ZLinq/Linq/Append.cs
+++ b/src/ZLinq/Linq/Append.cs
@@ -32,7 +32,7 @@ namespace ZLinq.Linq
 
         public bool TryGetNonEnumeratedCount(out int count)
         {
-            if (source.TryGetNonEnumeratedCount(out count))
+            if (source.TryGetNonEnumeratedCount(out count) && count < int.MaxValue)
             {
                 count++;
                 return true;

--- a/src/ZLinq/Linq/Prepend.cs
+++ b/src/ZLinq/Linq/Prepend.cs
@@ -33,7 +33,7 @@ namespace ZLinq.Linq
 
         public bool TryGetNonEnumeratedCount(out int count)
         {
-            if (source.TryGetNonEnumeratedCount(out count))
+            if (source.TryGetNonEnumeratedCount(out count) && count < int.MaxValue)
             {
                 count++;
                 return true;


### PR DESCRIPTION
There was a difference in results between Linq and ZLinq in the following edge case.

```csharp
var intMaxSequence = Enumerable.Range(0, int.MaxValue); 
var countForLinq = intMaxSequence.Append(1).LongCount();                        //  2147483648
var countForZLinq = intMaxSequence.AsValueEnumerable().Append(1).LongCount();   // -2147483648

var countForLinq2 = intMaxSequence.Prepend(1).LongCount();                      //  2147483648
var countForZLinq2 = intMaxSequence.AsValueEnumerable().Prepend(1).LongCount(); // -2147483648
```

The cause was that `TryGetNonEnumeratedCount` for `Append` and `Prepend` exceeded int.MaxValue, so I added a process to check if the count is less than `int.MaxValue`.

```csharp
public bool TryGetNonEnumeratedCount(out int count)
{
    if (source.TryGetNonEnumeratedCount(out count) && count < int.MaxValue)
    {
        count++;
        return true;
    }
    count = 0;
    return false;
}
```

Please confirm if this fix is appropriate.
