### PR TITLE
Chore modify analyzer settings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -42,5 +42,8 @@ trim_trailing_whitespace = false
 
 # C# code style settings
 [*.{cs}]
+dotnet_diagnostic.IDE0044.severity = none # IDE0044: Make field readonly
+
 # https://stackoverflow.com/questions/79195382/how-to-disable-fading-unused-methods-in-visual-studio-2022-17-12-0
-dotnet_diagnostic.IDE0051.severity = none
+dotnet_diagnostic.IDE0051.severity = none # IDE0051: Remove unused private member
+dotnet_diagnostic.IDE0130.severity = none # IDE0130: Namespace does not match folder structure

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -29,7 +29,11 @@
 
     <!-- NuGet Missing Compiler Flags -->
     <Features>strict</Features>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+
     <!-- CS9074: The 'scoped' modifier of parameter 'span' doesn't match overridden or implemented member.-->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CS9074</WarningsNotAsErrors>
   </PropertyGroup>

--- a/sandbox/.editorconfig
+++ b/sandbox/.editorconfig
@@ -1,0 +1,5 @@
+﻿root = false
+
+[*.{cs}]
+dotnet_diagnostic.CA1822.severity = silent # CA1822: Mark members as static
+

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -1,0 +1,6 @@
+﻿root = false
+
+[*.{cs}]
+dotnet_diagnostic.CA1806.severity = silent # CA1806: Do not ignore method results
+dotnet_diagnostic.CA1861.severity = silent # CA1861: Avoid constant arrays as arguments
+


### PR DESCRIPTION
This PR contains following changes.

### 1. Change `TreatWarningsAsErrors` condition to CI environment only
When editing source code on local environment.
I thought It's better that warnings are shown as is.

If there is a need to simulate CI build. it can be confirmed by manually add `/p:ContinuousIntegrationBuild=true` parameter.

### 2. Add suppression for unnecessary analyzer messages

#### IDE0044: Make field readonly
This rule seems to cause defensive-copy of mutable-struct.
So suppress this rule on solution level. 

#### IDE0130: Namespace does not match folder structure
This rule is not matched on current solution structure.
So suppress this rule on solution level. 

#### CA1822: Mark members as static
Suppress this rule on sandbox projects.

#### CA1806: Do not ignore method results
#### CA1861: Avoid constant arrays as arguments
Suppress these rules on test projects.


