### PR TITLE
perf: Shuffle followed by Take/Skip/TakeLast/SkipLast

### DIFF
--- a/sandbox/Benchmark/Benchmarks/ShuffleBench.cs
+++ b/sandbox/Benchmark/Benchmarks/ShuffleBench.cs
@@ -1,12 +1,59 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using System.Runtime.InteropServices;
+using ZLinq;
 
-namespace Benchmark
+namespace Benchmark;
+
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class ShuffleBench
 {
-    class ShuffleBench
+    [Params(/*10, 100,*/ 1000, /*10000,*/ 100000)]
+    public int N;
+
+    [Params(10, 100, 1000, 100000)]
+    public int M;
+
+    int[] array = default!;
+
+    [GlobalSetup]
+    public void Setup()
     {
+        var rand = new Random(42);
+        array = new int[N];
+        rand.NextBytes(MemoryMarshal.Cast<int, byte>(array));
     }
+
+#if NET10_0_OR_GREATER
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public int ShuffleTakeLinq()
+    {
+        var src = array.Shuffle().Take(M);
+        int i = 0;
+        using var e = src.GetEnumerator();
+        while (e.MoveNext())
+        {
+            i++;
+            _ = e.Current;
+        }
+        return i;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public int ShuffleTakeZL()
+    {
+        var src = array.AsValueEnumerable().Shuffle().Take(M);
+        int i = 0;
+        using var e = src.Enumerator;
+        while (e.TryGetNext(out var item))
+        {
+            i++;
+        }
+        return i;
+    }
+
+#endif
 }

--- a/sandbox/Benchmark/Benchmarks/ShuffleBench.cs
+++ b/sandbox/Benchmark/Benchmarks/ShuffleBench.cs
@@ -19,9 +19,7 @@ public class ShuffleBench
     [GlobalSetup]
     public void Setup()
     {
-        var rand = new Random(42);
-        array = new int[N];
-        rand.NextBytes(MemoryMarshal.Cast<int, byte>(array));
+        array = Enumerable.Range(0, N).ToArray();
     }
 
 #if NET10_0_OR_GREATER

--- a/src/ZLinq/Internal/RandomShared.cs
+++ b/src/ZLinq/Internal/RandomShared.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Security.Cryptography;
-using System.Text;
+﻿using System.Security.Cryptography;
 
 namespace ZLinq.Internal;
 
@@ -22,6 +19,24 @@ internal static class RandomShared
         Random.Shared.Shuffle(span);
 #else
         Shared.Value.Shuffle(span);
+#endif
+    }
+
+    public static void Shuffle<T>(T[] array, int count)
+    {
+#if NET8_0_OR_GREATER
+        Random.Shared.Shuffle(array.AsSpan(), count);
+#else
+        Shared.Value.Shuffle(array.AsSpan(), count);
+#endif
+    }
+
+    public static void Shuffle<T>(Span<T> span, int count)
+    {
+#if NET8_0_OR_GREATER
+        Random.Shared.Shuffle(span, count);
+#else
+        Shared.Value.Shuffle(span, count);
 #endif
     }
 
@@ -56,4 +71,33 @@ internal static class RandomShared
     }
 
 #endif
+
+    static void Shuffle<T>(this Random random, Span<T> values, int count)
+    {
+        if (count <= 0)
+            return;
+
+        int length = values.Length;
+        if (count > length)
+            count = length;
+
+        int n = length;
+        if (n > count)
+            n = count;
+
+        if (n == length)
+            n--;  // exclude last item
+
+        for (int i = 0; i < n; i++)
+        {
+            int j = random.Next(i, length);
+
+            if (j != i)
+            {
+                T temp = values[i];
+                values[i] = values[j];
+                values[j] = temp;
+            }
+        }
+    }
 }

--- a/src/ZLinq/Linq/Shuffle.SkipShuffle.cs
+++ b/src/ZLinq/Linq/Shuffle.SkipShuffle.cs
@@ -54,7 +54,7 @@ namespace ZLinq.Linq
 #else
     public
 #endif
-    struct SkipShuffle<TEnumerator, TSource>(Shuffle<TEnumerator, TSource> shuffle, int count, bool skip)
+    struct SkipShuffle<TEnumerator, TSource>(Shuffle<TEnumerator, TSource> shuffle, int count, bool skipOrTake)
         : IValueEnumerator<TSource>
         where TEnumerator : struct, IValueEnumerator<TSource>
 #if NET9_0_OR_GREATER
@@ -65,7 +65,7 @@ namespace ZLinq.Linq
         RentedArrayBox<TSource>? buffer;
         int index = 0;
         readonly int count = count < 0 ? 0 : count;
-        readonly bool skip = skip;
+        readonly bool skipOrTake = skipOrTake;
 
         public bool TryGetNonEnumeratedCount(out int count)
         {
@@ -127,7 +127,7 @@ namespace ZLinq.Linq
                 var (array, consumed) = new ValueEnumerable<TEnumerator, TSource>(source).ToArrayPool();
                 var count = consumed;
 
-                if (skip)
+                if (skipOrTake)
                 {
                     count -= this.count;
 

--- a/src/ZLinq/Linq/Shuffle.SkipShuffle.cs
+++ b/src/ZLinq/Linq/Shuffle.SkipShuffle.cs
@@ -120,6 +120,7 @@ namespace ZLinq.Linq
         }
 
         [MemberNotNull(nameof(buffer))]
+        [MethodImpl(MethodImplOptions.NoInlining)]
         void InitBuffer()
         {
             if (buffer == null)

--- a/src/ZLinq/Linq/Shuffle.SkipShuffle.cs
+++ b/src/ZLinq/Linq/Shuffle.SkipShuffle.cs
@@ -1,0 +1,156 @@
+﻿using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
+
+namespace ZLinq
+{
+    partial class ValueEnumerableExtensions
+    {
+        public static ValueEnumerable<SkipShuffle<TEnumerator, TSource>, TSource> Take<TEnumerator, TSource>(this ValueEnumerable<Shuffle<TEnumerator, TSource>, TSource> source, int count)
+            where TEnumerator : struct, IValueEnumerator<TSource>
+#if NET9_0_OR_GREATER
+            , allows ref struct
+#endif
+        {
+            return new(new(source.Enumerator, count, false));
+        }
+
+        public static ValueEnumerable<SkipShuffle<TEnumerator, TSource>, TSource> Skip<TEnumerator, TSource>(this ValueEnumerable<Shuffle<TEnumerator, TSource>, TSource> source, int count)
+            where TEnumerator : struct, IValueEnumerator<TSource>
+#if NET9_0_OR_GREATER
+            , allows ref struct
+#endif
+        {
+            return new(new(source.Enumerator, count, true));
+        }
+
+        // 'Last' variants are syntax sugar. just takes specified count of items randomly from source.
+
+        public static ValueEnumerable<SkipShuffle<TEnumerator, TSource>, TSource> TakeLast<TEnumerator, TSource>(this ValueEnumerable<Shuffle<TEnumerator, TSource>, TSource> source, int count)
+            where TEnumerator : struct, IValueEnumerator<TSource>
+#if NET9_0_OR_GREATER
+            , allows ref struct
+#endif
+        {
+            return new(new(source.Enumerator, count, false));
+        }
+
+        public static ValueEnumerable<SkipShuffle<TEnumerator, TSource>, TSource> SkipLast<TEnumerator, TSource>(this ValueEnumerable<Shuffle<TEnumerator, TSource>, TSource> source, int count)
+            where TEnumerator : struct, IValueEnumerator<TSource>
+#if NET9_0_OR_GREATER
+            , allows ref struct
+#endif
+        {
+            return new(new(source.Enumerator, count, true));
+        }
+    }
+}
+
+namespace ZLinq.Linq
+{
+    [StructLayout(LayoutKind.Auto)]
+    [EditorBrowsable(EditorBrowsableState.Never)]
+#if NET9_0_OR_GREATER
+    public ref
+#else
+    public
+#endif
+    struct SkipShuffle<TEnumerator, TSource>(Shuffle<TEnumerator, TSource> shuffle, int count, bool skip)
+        : IValueEnumerator<TSource>
+        where TEnumerator : struct, IValueEnumerator<TSource>
+#if NET9_0_OR_GREATER
+        , allows ref struct
+#endif
+    {
+        TEnumerator source = shuffle.source;
+        RentedArrayBox<TSource>? buffer;
+        int index = 0;
+        readonly int count = count < 0 ? 0 : count;
+        readonly bool skip = skip;
+
+        public bool TryGetNonEnumeratedCount(out int count)
+        {
+            if (!source.TryGetNonEnumeratedCount(out count))
+                return false;
+
+            InitBuffer();
+
+            count = buffer.Length;
+            return true;
+        }
+
+        public bool TryGetSpan(out ReadOnlySpan<TSource> span)
+        {
+            InitBuffer();
+            span = buffer.Span;
+            return true;
+        }
+
+        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        {
+            InitBuffer();
+
+            if (EnumeratorHelper.TryGetSlice<TSource>(buffer.Span, offset, destination.Length, out var slice))
+            {
+                slice.CopyTo(destination);
+                return true;
+            }
+
+            return false;
+        }
+
+        public bool TryGetNext(out TSource current)
+        {
+            if (buffer == null)
+                InitBuffer();
+
+            if (index < buffer.Length)  // use buffer.Length. 'this.count' may be greater.
+            {
+                current = buffer.UnsafeGetAt(index++);
+                return true;
+            }
+
+            Unsafe.SkipInit(out current);
+            return false;
+        }
+
+        public void Dispose()
+        {
+            buffer?.Dispose();
+            source.Dispose();
+        }
+
+        [MemberNotNull(nameof(buffer))]
+        void InitBuffer()
+        {
+            if (buffer == null)
+            {
+                var (array, consumed) = new ValueEnumerable<TEnumerator, TSource>(source).ToArrayPool();
+                var count = consumed;
+
+                if (skip)
+                {
+                    count -= this.count;
+
+                    if (count < 0)
+                        count = 0;
+                }
+                else
+                {
+                    if (count > this.count)
+                        count = this.count;
+                }
+
+                if (count == 0)
+                {
+                    ArrayPool<TSource>.Shared.Return(array, clearArray: RuntimeHelpers.IsReferenceOrContainsReferences<TSource>());
+                    buffer = RentedArrayBox<TSource>.Empty;
+                }
+                else
+                {
+                    RandomShared.Shuffle(array.AsSpan(0, consumed), count);  // must slice by array pool consumed length!!
+                    buffer = new RentedArrayBox<TSource>(array, count);
+                }
+            }
+        }
+    }
+}

--- a/src/ZLinq/Linq/Shuffle.cs
+++ b/src/ZLinq/Linq/Shuffle.cs
@@ -29,7 +29,7 @@ namespace ZLinq.Linq
         , allows ref struct
 #endif
     {
-        TEnumerator source = source;
+        internal TEnumerator source = source;
         RentedArrayBox<TSource>? buffer;
         int index = 0;
 

--- a/tests/ZLinq.Tests/Linq/ShuffleSkipTest.cs
+++ b/tests/ZLinq.Tests/Linq/ShuffleSkipTest.cs
@@ -1,0 +1,212 @@
+﻿namespace ZLinq.Tests.Linq;
+
+public class ShuffleSkipTest
+{
+    [Fact]
+    public void Shuffle_Skip()
+    {
+        var source = new[] { 5, 2, 8, 1, 9, 3, 7, 4, 6 };
+
+        // Skip first 3 elements
+        var result = source.AsValueEnumerable()
+            .Shuffle()
+            .Skip(3)
+            .ToArray();
+        result.Length.ShouldBe(source.Length - 3);
+
+        // skip all
+        result = source.AsValueEnumerable()
+            .Shuffle()
+            .Skip(int.MaxValue)
+            .ToArray();
+        result.Length.ShouldBe(0);
+
+        // skip none
+        result = source.AsValueEnumerable()
+            .Shuffle()
+            .Skip(int.MinValue)
+            .ToArray();
+        result.Length.ShouldBe(source.Length);
+    }
+
+    [Fact]
+    public void Shuffle_SkipLast()
+    {
+        var source = new[] { 5, 2, 8, 1, 9, 3, 7, 4, 6 };
+
+        // Skip first 3 elements
+        var result = source.AsValueEnumerable()
+            .Shuffle()
+            .SkipLast(3)
+            .ToArray();
+        result.Length.ShouldBe(source.Length - 3);
+
+        // skip all
+        result = source.AsValueEnumerable()
+            .Shuffle()
+            .SkipLast(int.MaxValue)
+            .ToArray();
+        result.Length.ShouldBe(0);
+
+        // skip none
+        result = source.AsValueEnumerable()
+            .Shuffle()
+            .SkipLast(int.MinValue)
+            .ToArray();
+        result.Length.ShouldBe(source.Length);
+    }
+
+    [Fact]
+    public void Shuffle_Take()
+    {
+        var source = new[] { 5, 2, 8, 1, 9, 3, 7, 4, 6 };
+
+        // Take first 4 elements
+        var result = source.AsValueEnumerable()
+            .Shuffle()
+            .Take(4)
+            .ToArray();
+        result.Length.ShouldBe(4);
+
+        // take all
+        result = source.AsValueEnumerable()
+            .Shuffle()
+            .Take(int.MaxValue)
+            .ToArray();
+        result.Length.ShouldBe(source.Length);
+
+        // take none
+        result = source.AsValueEnumerable()
+            .Shuffle()
+            .Take(int.MinValue)
+            .ToArray();
+        result.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Shuffle_TakeLast()
+    {
+        var source = new[] { 5, 2, 8, 1, 9, 3, 7, 4, 6 };
+
+        // Take first 4 elements
+        var result = source.AsValueEnumerable()
+            .Shuffle()
+            .TakeLast(4)
+            .ToArray();
+        result.Length.ShouldBe(4);
+
+        // take all
+        result = source.AsValueEnumerable()
+            .Shuffle()
+            .TakeLast(int.MaxValue)
+            .ToArray();
+        result.Length.ShouldBe(source.Length);
+
+        // take none
+        result = source.AsValueEnumerable()
+            .Shuffle()
+            .TakeLast(int.MinValue)
+            .ToArray();
+        result.Length.ShouldBe(0);
+    }
+
+    [Fact]
+    public void Shuffle_Skip_TryGetNonEnumeratedCount()
+    {
+        var source = new[] { 5, 2, 8, 1, 9, 3, 7, 4, 6 };
+
+        var query = source.AsValueEnumerable()
+            .Shuffle()
+            .Skip(3);
+
+        query.TryGetNonEnumeratedCount(out var count).ShouldBeTrue();
+        count.ShouldBe(6); // 9 - 3 = 6
+    }
+
+    [Fact]
+    public void Shuffle_SkipLast_TryGetNonEnumeratedCount()
+    {
+        var source = new[] { 5, 2, 8, 1, 9, 3, 7, 4, 6 };
+
+        var query = source.AsValueEnumerable()
+            .Shuffle()
+            .SkipLast(3);
+
+        query.TryGetNonEnumeratedCount(out var count).ShouldBeTrue();
+        count.ShouldBe(6); // 9 - 3 = 6
+    }
+
+    [Fact]
+    public void Shuffle_Take_TryGetNonEnumeratedCount()
+    {
+        var source = new[] { 5, 2, 8, 1, 9, 3, 7, 4, 6 };
+
+        var query = source.AsValueEnumerable()
+            .Shuffle()
+            .Take(4);
+
+        query.TryGetNonEnumeratedCount(out var count).ShouldBeTrue();
+        count.ShouldBe(4);
+    }
+
+    [Fact]
+    public void Shuffle_TakeLast_TryGetNonEnumeratedCount()
+    {
+        var source = new[] { 5, 2, 8, 1, 9, 3, 7, 4, 6 };
+
+        var query = source.AsValueEnumerable()
+            .Shuffle()
+            .TakeLast(4);
+
+        query.TryGetNonEnumeratedCount(out var count).ShouldBeTrue();
+        count.ShouldBe(4);
+    }
+
+    [Fact]
+    public void Shuffle()
+    {
+        // internally using ToArrayPool(). source size should not be power-of-2 for testing.
+        var source = Enumerable.Range(0, 567).ToArray();
+
+        List<int> list;
+        list = source.AsValueEnumerable().Shuffle().TakeLast(int.MaxValue).ToList();
+        Test(source, list);
+        list = source.AsValueEnumerable().Shuffle().Take(int.MaxValue).ToList();
+        Test(source, list);
+        list = source.AsValueEnumerable().Shuffle().SkipLast(0).ToList();
+        Test(source, list);
+        list = source.AsValueEnumerable().Shuffle().Skip(0).ToList();
+        Test(source, list);
+
+        static void Test(int[] source, List<int> list)
+        {
+            list.Count.ShouldBe(source.Length);
+            list.ToArray().ShouldNotBe(source);
+
+            // no duplicates?
+            foreach (var val in source)
+            {
+                list.Remove(val).ShouldBeTrue();
+                list.IndexOf(val).ShouldBe(-1);
+            }
+
+            list.ShouldBeEmpty();
+        }
+
+        const int size = 100;
+
+        // shuffle correctly takes items from all available source items?
+        var items = source.Take(size).ToArray();
+        source.AsValueEnumerable().Shuffle().Take(size).ToList().Except(items).ShouldNotBeEmpty();
+        source.AsValueEnumerable().Shuffle().TakeLast(size).ToList().Except(items).ShouldNotBeEmpty();
+        source.Except(source.AsValueEnumerable().Shuffle().Take(size).ToList()).Count().ShouldBe(source.Length - size);
+        source.Except(source.AsValueEnumerable().Shuffle().TakeLast(size).ToList()).Count().ShouldBe(source.Length - size);
+
+        items = source.Skip(size).ToArray();
+        source.AsValueEnumerable().Shuffle().Skip(size).ToList().Except(items).ShouldNotBeEmpty();
+        source.AsValueEnumerable().Shuffle().SkipLast(size).ToList().Except(items).ShouldNotBeEmpty();
+        source.Except(source.AsValueEnumerable().Shuffle().Skip(size).ToList()).Count().ShouldBe(size);
+        source.Except(source.AsValueEnumerable().Shuffle().SkipLast(size).ToList()).Count().ShouldBe(size);
+    }
+
+}


### PR DESCRIPTION
Similar optimization to order and take/skip combo.


## Considerations

`shuffle().take()` will compacting enumerator connection from:
- array -> shuffle -> take

to:
- array -> skipShuffle

intermediate shuffle will be hidden orphan branch, but it will never take internal buffer until consumed so it won't be a problem.


## Benchmarks

Add .NET 10.0 as a target and the following code at the beginning of Main().
```cs
BenchmarkRunner.Run(typeof(ShuffleBench));
return 0;
```

Then, set build target to `net10.0` and go ahead.

| Method          | N      | M      | Mean         | Error        | StdDev       |
|---------------- |------- |------- |-------------:|-------------:|-------------:|
| ShuffleTakeLinq | 1000   | 10     |   3,560.3 ns |     16.58 ns |     14.69 ns |
| ShuffleTakeLinq | 1000   | 100    |   5,853.1 ns |     31.23 ns |     29.22 ns |
| ShuffleTakeLinq | 1000   | 1000   |   6,365.5 ns |     79.05 ns |     70.08 ns |
| ShuffleTakeLinq | 1000   | 100000 |   6,278.3 ns |     28.74 ns |     25.48 ns |
| ShuffleTakeZL   | 1000   | 10     |     106.1 ns |      0.61 ns |      0.57 ns |
| ShuffleTakeZL   | 1000   | 100    |     551.5 ns |      1.41 ns |      1.32 ns |
| ShuffleTakeZL   | 1000   | 1000   |   5,197.1 ns |     28.21 ns |     23.56 ns |
| ShuffleTakeZL   | 1000   | 100000 |   5,442.6 ns |     23.21 ns |     21.71 ns |
|                 |        |        |              |              |              |
| ShuffleTakeLinq | 100000 | 10     | 303,312.2 ns |  1,473.92 ns |  1,378.71 ns |
| ShuffleTakeLinq | 100000 | 100    | 310,066.7 ns |  1,528.47 ns |  1,276.34 ns |
| ShuffleTakeLinq | 100000 | 1000   | 351,249.2 ns |  3,069.96 ns |  2,721.44 ns |
| ShuffleTakeLinq | 100000 | 100000 | 790,944.2 ns | 13,770.01 ns | 13,523.99 ns |
| ShuffleTakeZL   | 100000 | 10     |  11,649.3 ns |    232.66 ns |    228.51 ns |
| ShuffleTakeZL   | 100000 | 100    |  12,209.2 ns |    238.38 ns |    222.98 ns |
| ShuffleTakeZL   | 100000 | 1000   |  17,677.4 ns |    322.27 ns |    285.69 ns |
| ShuffleTakeZL   | 100000 | 100000 | 493,672.9 ns |  2,925.18 ns |  2,442.66 ns |
