### PR TITLE
chore: Fix consume extension method performance

### DIFF
--- a/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/BaseBenchmarkConfig.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/BaseBenchmarkConfig.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Columns;
+using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Engines;

--- a/sandbox/Benchmark/BenchmarkDotNet/EventProcessors/BenchmarkEventProcessor.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/EventProcessors/BenchmarkEventProcessor.cs
@@ -1,5 +1,4 @@
-﻿using BenchmarkDotNet.Analysers;
-using BenchmarkDotNet.Engines;
+using BenchmarkDotNet.Analysers;
 using BenchmarkDotNet.EventProcessors;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
@@ -22,6 +21,7 @@ public class BenchmarkEventProcessor : EventProcessor
     private int completedBenchmarkCount = 0;
 
     private int maxBenchmarkMethodNameLength = 0;
+    private int maxBenchmarkParameterInfoLength = 0;
     private bool containsMultipleJobIds = false;
 
     public static readonly BenchmarkEventProcessor Instance = new();
@@ -87,6 +87,11 @@ public class BenchmarkEventProcessor : EventProcessor
         // Gets max length of benchmark method name.
         maxBenchmarkMethodNameLength = benchmarks.Count > 0
             ? benchmarks.Max(x => x.Descriptor.WorkloadMethod.Name.Length)
+            : 0;
+
+        // Gets max length of benchmark parameters info.
+        maxBenchmarkParameterInfoLength = benchmarks.Count > 0
+            ? benchmarks.Max(x => x.HasParameters ? x.Parameters.PrintInfo.Length : 0)
             : 0;
 
         // Gets benchmarks contains multiple JobIds or not.
@@ -204,7 +209,11 @@ public class BenchmarkEventProcessor : EventProcessor
         sb.Append(methodName);
 
         if (benchmarkCase.HasParameters)
-            sb.Append($" ({benchmarkCase.Parameters.PrintInfo})");
+        {
+            var parametersInfo = benchmarkCase.Parameters.PrintInfo;
+            var parametersInfoWithParentheses = $"({parametersInfo})".PadRight(maxBenchmarkParameterInfoLength + 2);
+            sb.Append($" {parametersInfoWithParentheses}");
+        }
 
         if (containsMultipleJobIds)
             sb.Append($" JobId({benchmarkCase.Job.ResolvedId})");

--- a/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/ConsumerExtensions.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/ConsumerExtensions.cs
@@ -1,0 +1,78 @@
+using BenchmarkDotNet.Engines;
+using ZLinq;
+using ZLinq.Linq;
+
+namespace Benchmark;
+
+/// <summary>
+/// Helper class that provide extension method that executes and consumes given <see cref="ValueEnumerable{TEnumerator, T}"/>
+/// </summary>
+/// <remarks>
+/// This class define Consume extension method per ValueEnumerable types.
+/// Because when calling TryGetNext via IValueEnumerator interface.
+/// It run slightly slower because it use callvirt.
+/// </remarks>
+internal static partial class ConsumerExtensions
+{
+    [Obsolete("Consume extension methods that accept IValueEnumerator<T> should not be used. because it runs slower.")]
+    public static void Consume<TEnumerator, T>(this ValueEnumerable<TEnumerator, T> enumerable, Consumer consumer)
+        where TEnumerator : struct, IValueEnumerator<T>
+#if NET9_0_OR_GREATER
+            , allows ref struct
+#endif
+    {
+        using var e = enumerable.Enumerator;
+        while (e.TryGetNext(out var item))
+        {
+            consumer.Consume(in item);
+        }
+    }
+
+    // Select FromEnumerable
+    public static void Consume<T>(this ValueEnumerable<Select<FromEnumerable<T>, T, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+
+    // Select FromArray
+    public static void Consume<T>(this ValueEnumerable<Select<FromArray<T>, T, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+
+    // Select FromList
+    public static void Consume<T>(this ValueEnumerable<Select<FromList<T>, T, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+
+    // Select x2 FromArray
+    public static void Consume<T>(this ValueEnumerable<Select<Select<FromArray<T>, T, T>, T, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+
+    // Select x3 FromArray
+    public static void Consume<T>(this ValueEnumerable<Select<Select<Select<FromArray<T>, T, T>, T, T>, T, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+
+    // Select x4 FromArray
+    public static void Consume<T>(this ValueEnumerable<Select<Select<Select<Select<FromArray<T>, T, T>, T, T>, T, T>, T, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+}

--- a/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/ExtensionMethods.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/ExtensionMethods.cs
@@ -1,26 +1,9 @@
-﻿using BenchmarkDotNet.Engines;
 using ZLinq;
 
 namespace Benchmark;
 
 internal static class ExtensionMethods
 {
-    /// <summary>
-    /// Executes and consumes given <see cref="ValueEnumerable{TEnumerator, T}"/>.
-    /// </summary>
-    public static void Consume<TEnumerator, T>(this ValueEnumerable<TEnumerator, T> enumerable, Consumer consumer)
-        where TEnumerator : struct, IValueEnumerator<T>
-#if NET9_0_OR_GREATER
-            , allows ref struct
-#endif
-    {
-        using var e = enumerable.Enumerator;
-        while (e.TryGetNext(out var item))
-        {
-            consumer.Consume(in item);
-        }
-    }
-
     /// <summary>
     /// Gets display name of specified type.
     /// </summary>

--- a/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/SummariesExtensions.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/SummariesExtensions.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Environments;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Loggers;
 using BenchmarkDotNet.Reports;
@@ -34,10 +34,10 @@ public static partial class SummariesExtensions
             Summary summary = items[0];
             var benchmarkTypeName = summary.BenchmarksCases[0].Descriptor.Type.GetDisplayName();
 
-            // Join generic type benchmarks summaries.
+            // Join benchmarks summaries that using generic type.
             if (items.Length > 1)
             {
-                // benchmarkTypeName = grouping.Key.Replace("`1", "<T>");
+                benchmarkTypeName = grouping.Key.Replace("`1", "<T>");
                 summary = Join(items, TimeSpan.FromTicks(items.Sum(x => x.TotalTime.Ticks)));
             }
 

--- a/sandbox/Benchmark/Benchmarks/SelectFromSourceTypes.cs
+++ b/sandbox/Benchmark/Benchmarks/SelectFromSourceTypes.cs
@@ -1,0 +1,63 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Engines;
+using ZLinq;
+
+namespace Benchmark;
+
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[GenericTypeArguments(typeof(string))]
+public class SelectFromSourceTypes<T> where T : notnull
+{
+    readonly Consumer consumer = new();
+
+    readonly T[] source = Enumerable.Range(1, 10_000_000).Select(x => default(T)!).ToArray();
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public void LinqSelect()
+    {
+        source.Select(x => x)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public void LinqSelect_WithoutConsume()
+    {
+        foreach (var _ in source.Select(x => x))
+        {
+        }
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public void ZLinqSelect()
+    {
+        source.AsValueEnumerable()
+              .Select(x => x)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public void ZLinqSelect_WithoutConsume()
+    {
+        var valueEnumerable = source.AsValueEnumerable().Select(x => x);
+        using var e = valueEnumerable.Enumerator;
+        while (e.TryGetNext(out _))
+        {
+        }
+    }
+
+    // ValueEnumerable.Consume performance should be same as following code.
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public void ZLinq_ConsumeDirect()
+    {
+        var valueEnumerable = source.AsValueEnumerable().Select(x => x);
+        using var e = valueEnumerable.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(item);
+    }
+}

--- a/sandbox/Benchmark/Properties/launchSettings.json
+++ b/sandbox/Benchmark/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Default": {
       "commandName": "Project",
-      "commandLineArgs": "--filter Benchmark.SelectFromEnumerableArray.* -- Default",
+      "commandLineArgs": "--filter Benchmark.SelectFromSourceTypes* -- Default",
 
       // Available config
       // 1. Default
@@ -40,6 +40,8 @@
       // "commandLineArgs": "--filter Benchmark.ReadMeBenchmark.*",
       // "commandLineArgs": "--filter Benchmark.Select4.*",
       // "commandLineArgs": "--filter Benchmark.Select4_Consume.*",
+      // "commandLineArgs": "--filter Benchmark.SelectFromEnumerableArray.*",
+      // "commandLineArgs": "--filter Benchmark.SelectFromSourceTypes*",
       // "commandLineArgs": "--filter Benchmark.ShuffleBench.*",
       // "commandLineArgs": "--filter Benchmark.SimdAny.*",
       // "commandLineArgs": "--filter Benchmark.SimdCount.*",


### PR DESCRIPTION
This PR intended to fix `ValueEnumerable::Consume` extension method performance.

Currently Consume extension accepts `IValueEnumerator<T>`.
But when using this abstraction. `TryGetNext` is invoked with `callvirt`.
And it slightly run slower. And affect ZLinq benchmarks results.

This PR include following changes.
1. Add Consume extension methods per ValueEnumerable types to optimize performance.
2. Add `[Obsolete]` attribute to existing `IValueEnumerator<T>` based extension method.

#### Benchmark Results
After this PR applied.
ZLinqSelect benchmark result has similar performance to ZLinq_ConsumeDirect.
(When using `IValueEnumerator<T>` based extension method. `ZLinqSelect` takes about `115.66 ms`)

**Benchmark Results: SelectFromSourceTypes<String>**

| Method                     | Mean     | Error     | StdDev   | Allocated |
|--------------------------- |---------:|----------:|---------:|----------:|
| LinqSelect                 | 47.90 ms | 12.803 ms | 0.702 ms |      62 B |
| LinqSelect_WithoutConsume  | 36.00 ms |  8.372 ms | 0.459 ms |      56 B |
|                            |          |           |          |           |
| ZLinqSelect                | 65.41 ms | 11.627 ms | 0.637 ms |      11 B |
| ZLinqSelect_WithoutConsume | 48.96 ms | 70.745 ms | 3.878 ms |      14 B |
| ZLinq_ConsumeDirect        | 62.93 ms | 19.266 ms | 1.056 ms |       9 B |

Note:
When running **simple** Select benchmark with *Reference Type* (e.g. string/class/record class).
It seems ZLinq run slower than Systen.Linq.

#### Additional Changes
This PR includes following additional changes.

**BenchmarkEventProcessor.cs**
Fix console output indents for parameter. 
It's required when multiple argument patterns specified (e.g. 1, 10, 100) 

****SummariesExtensions.cs``
Modify markdown table header name.

Currently when using benchmark that has generic types.
It display joined markdown table. But table header show first benchmark type name. (e.g.  `Benchmark<int>`
This PR change change display name to `Benchmark<T>`
