### PR TITLE
chore: Add badges to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 ZLinq
 ===
+[![CI](https://github.com/Cysharp/ZLinq/actions/workflows/build-debug.yml/badge.svg)](https://github.com/Cysharp/ZLinq/actions/workflows/build-debug.yml)
+[![Benchmark](https://github.com/Cysharp/ZLinq/actions/workflows/benchmark.yml/badge.svg)](https://github.com/Cysharp/ZLinq/actions/workflows/benchmark.yml)
+[![NuGet](https://img.shields.io/nuget/v/ZLinq)](https://www.nuget.org/packages/ZLinq)
+[![DeepWiki](https://img.shields.io/badge/Chat%20with-DeepWiki%20🤖-blue)](https://deepwiki.com/Cysharp/ZLinq)
+
 Zero allocation LINQ with LINQ to Span, LINQ to SIMD, and LINQ to Tree (FileSystem, JSON, GameObject, etc.) for all .NET platforms(netstandard2.0, 2.1, net8, net9) and Unity, Godot.
 
 ![](img/benchmarkhead.jpg)


### PR DESCRIPTION
This PR add following badges to `README.md`

1. CI Build workflow status
2. Benchmark workflow status
3. NuGet published package link
4. [DeepWiki](https://deepwiki.com/Cysharp/ZLinq) link

## Rendered badges with clickable link
[![CI](https://github.com/Cysharp/ZLinq/actions/workflows/build-debug.yml/badge.svg)](https://github.com/Cysharp/ZLinq/actions/workflows/build-debug.yml)
[![Benchmark](https://github.com/Cysharp/ZLinq/actions/workflows/benchmark.yml/badge.svg)](https://github.com/Cysharp/ZLinq/actions/workflows/benchmark.yml)
[![NuGet](https://img.shields.io/nuget/v/ZLinq)](https://www.nuget.org/packages/ZLinq)
[![DeepWiki](https://img.shields.io/badge/Chat%20with-DeepWiki%20🤖-blue)](https://deepwiki.com/Cysharp/ZLinq)

## Rendered badge image
![image](https://github.com/user-attachments/assets/db8fbd80-b5a3-4e79-b0aa-dbdd37d4e12a)
