### PR TITLE
Improve LongCount(predicate) from array performance

### DIFF
--- a/sandbox/Benchmark/Benchmarks/AllAnyPredicateWithCapturedLambda.cs
+++ b/sandbox/Benchmark/Benchmarks/AllAnyPredicateWithCapturedLambda.cs
@@ -110,3 +110,34 @@ public class CountPredicateWithCapturedLambda
         return _nums.Count(i => i <= _target);
     }
 }
+
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class LongCountPredicateWithCapturedLambda
+{
+    [Params(10, 100, 1000, 10000)]
+    public int N;
+
+    int[] _nums = default!;
+    int _target;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _nums = Enumerable.Range(1, N).ToArray();
+        _target = N;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    public long ZLinq()
+    {
+        return _nums.AsValueEnumerable().LongCount(i => i <= _target);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    public long Linq()
+    {
+        return _nums.LongCount(i => i <= _target);
+    }
+}

--- a/src/ZLinq/Linq/LongCount.cs
+++ b/src/ZLinq/Linq/LongCount.cs
@@ -71,18 +71,18 @@
                 return LongCount(array, predicate);
             }
 
-            var longcount = 0;
+            var longCount = 0;
 
             var span = (ReadOnlySpan<TSource>)array;
             for (int i = 0; i < span.Length; i++)
             {
                 if (predicate(span[i]))
                 {
-                    longcount++;
+                    longCount++;
                 }
             }
 
-            return longcount;
+            return longCount;
 
             [MethodImpl(MethodImplOptions.NoInlining)]
             static Int64 LongCount(TSource[] array, Func<TSource, Boolean> predicate)

--- a/src/ZLinq/Linq/LongCount.cs
+++ b/src/ZLinq/Linq/LongCount.cs
@@ -60,5 +60,44 @@
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static Int64 LongCount<TSource>(this ValueEnumerable<FromArray<TSource>, TSource> source, Func<TSource, Boolean> predicate)
+        {
+            ArgumentNullException.ThrowIfNull(predicate);
+
+            var array = source.Enumerator.GetSource();
+            if (array.GetType() != typeof(TSource[]))
+            {
+                return LongCount(array, predicate);
+            }
+
+            var longcount = 0;
+
+            var span = (ReadOnlySpan<TSource>)array;
+            for (int i = 0; i < span.Length; i++)
+            {
+                if (predicate(span[i]))
+                {
+                    longcount++;
+                }
+            }
+
+            return longcount;
+
+            [MethodImpl(MethodImplOptions.NoInlining)]
+            static Int64 LongCount(TSource[] array, Func<TSource, Boolean> predicate)
+            {
+                var longCount = 0;
+                for (int i = 0; i < array.Length; i++)
+                {
+                    if (predicate(array[i]))
+                    {
+                        longCount++;
+                    }
+                }
+                return longCount;
+            }
+        }
+
     }
 }


### PR DESCRIPTION
I have made the same changes to `LongCount` as to `Count`  in v1.4.2.
Please check if it looks good.