### PR TITLE
chore: fix build for .NET 10 preview4

### DIFF
--- a/src/ZLinq/Internal/SegmentedArrayProvider.cs
+++ b/src/ZLinq/Internal/SegmentedArrayProvider.cs
@@ -114,7 +114,10 @@ internal ref struct SegmentedArrayProvider<T>
     }
 }
 
-#if NET8_0_OR_GREATER
+#if NET10_0_OR_GREATER
+// .NET 10 or later supports build-in InlineArray16 implementation
+// https://source.dot.net/#System.Private.CoreLib/src/libraries/System.Private.CoreLib/src/System/Runtime/CompilerServices/InlineArray.cs
+#elif NET8_0_OR_GREATER
 
 [InlineArray(16)]
 internal struct InlineArray16<T>


### PR DESCRIPTION
This PR fix build error when using .NET 10 preview4 (It's occurred only when using Visual Studio Preview)

It's caused because .NET 10 preview4 or later contains build-in `InlineArray16<T>` implementation.
So It need to exclude ZLinq's `InlineArray16<T>`  implementation for .NET10 build.

---
Additionally .NET 10 preview 4 add following methods for FrozenCollection.
- [FrozenDictionary.Create](https://learn.microsoft.com/en-us/dotnet/api/system.collections.frozen.frozendictionary.create)
- [FrozenSet.Create](https://learn.microsoft.com/en-us/dotnet/api/system.collections.frozen.frozenset.create)

As far as I've confirmed.
These methods are simple wrapper and no performance benefits to use these methods.

**Example Code**

```csharp
    public static FrozenSet<TSource> ToFrozenSet<TEnumerator, TSource>(this ValueEnumerable<TEnumerator, TSource> source, IEqualityComparer<TSource>? comparer = null)
       where TEnumerator : struct, IValueEnumerator<TSource>
#if NET9_0_OR_GREATER
        , allows ref struct
#endif
    {
#if NET10_0_OR_GREATER
        using var e = source.Enumerator;
        if (e.TryGetSpan(out var span))
            return FrozenSet.Create(comparer, span); // Almost same performance to `source.ToHashSet().ToFrozenSet()`

        // When using ToArrayPool. it run slower 10-20%
        using var pooledArray = source.ToArrayPool();
        span = pooledArray.Span;
        return FrozenSet.Create(comparer, span);
#else
        return source.ToHashSet(comparer).ToFrozenSet(comparer);
#endif
    }
```
