### PR TITLE
chore: Fix benchmark report

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -51,6 +51,7 @@ jobs:
             $title = $title.Replace('-report-console.md', '')
             $title = $title.Replace('_Int32_' , '&lt;int&gt;')
             $title = $title.Replace('_String_', '&lt;string&gt;')
+            $title = $title.Replace('_Double_', '&lt;double&gt;')
 
             $content = Get-Content $item.FullName -Raw
             $tableContent = $content.Substring($content.IndexOf('|'))                        

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -45,8 +45,17 @@ jobs:
         working-directory: sandbox/Benchmark
         shell: pwsh
         run: |
-          $items = Get-ChildItem "BenchmarkDotNet.Artifacts/results/*.md"
+          $items = Get-ChildItem "BenchmarkDotNet.Artifacts/results/*.md" | where Name -ne 'reports.md'
           foreach($item in $items) {
-            Write-Output ('## {0}' -f $item.Name)          >> $env:GITHUB_STEP_SUMMARY
-            Write-Output (Get-Content $item.FullName -Raw) >> $env:GITHUB_STEP_SUMMARY
+            $title = $item.Name
+            $title = $title.Replace('-report-console.md', '')
+            $title = $title.Replace('_Int32_' , '&lt;int&gt;')
+            $title = $title.Replace('_String_', '&lt;string&gt;')
+
+            $content = Get-Content $item.FullName -Raw
+            $tableContent = $content.Substring($content.IndexOf('|'))                        
+            $tableContent.Replace('<', '&lt;').Replace('>', '&gt;')
+
+            Write-Output ('## {0}' -f $title)  >> $env:GITHUB_STEP_SUMMARY
+            Write-Output $tableContent         >> $env:GITHUB_STEP_SUMMARY
           }

--- a/sandbox/Benchmark/Benchmarks/ZLinq/MicroBenchmarks/BinaryOperations/ConcatBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/ZLinq/MicroBenchmarks/BinaryOperations/ConcatBenchmark.cs
@@ -14,14 +14,4 @@ public partial class ConcatBenchmark<T> : EnumerableBenchmarkBase_WithBasicTypes
               .Concat(source.ArrayData)
               .Consume(consumer);
     }
-
-    [Benchmark]
-    [BenchmarkCategory(Categories.From.Default)]
-    public void Concat_Enumerable()
-    {
-        source.Default
-              .AsValueEnumerable()
-              .Concat(source.EnumerableData)
-              .Consume(consumer);
-    }
 }

--- a/sandbox/Benchmark/Benchmarks/ZLinq/MicroBenchmarks/Sinks/CountByBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/ZLinq/MicroBenchmarks/Sinks/CountByBenchmark.cs
@@ -4,7 +4,7 @@ namespace Benchmark.ZLinq;
 
 #if !USE_SYSTEM_LINQ || NET9_0_OR_GREATER
 [BenchmarkCategory(Categories.Methods.CountBy)]
-public partial class CountBenchmark<T> : EnumerableBenchmarkBase_WithBasicTypes<T>
+public partial class CountByBenchmark<T> : EnumerableBenchmarkBase_WithBasicTypes<T>
 #if USE_SYSTEM_LINQ
     where T : notnull
 #endif

--- a/sandbox/Benchmark/README.md
+++ b/sandbox/Benchmark/README.md
@@ -24,13 +24,13 @@ It can start benchmarks with following command.
 $branchName = 'main'
 
 # Run benchmark with `Default` config
-gh workflow run benchmark.yml --repo Cysharp/ZLinq --ref $branchName
+gh workflow run benchmark.yaml --repo Cysharp/ZLinq --ref $branchName
 
 # Run benchmark with `Default` config with benchmark filter
-gh workflow run benchmark.yml --repo Cysharp/ZLinq --ref $branchName -f filter=Benchmark.ReadMeBenchmark*
+gh workflow run benchmark.yaml --repo Cysharp/ZLinq --ref $branchName -f filter=Benchmark.ReadMeBenchmark*
 
 # Run benchmark with `SystemLinq` config
-gh workflow run benchmark.yml --repo Cysharp/ZLinq --ref $branchName -f config=SystemLinq
+gh workflow run benchmark.yaml --repo Cysharp/ZLinq --ref $branchName -f config=SystemLinq
 ```
 
 Benchmark results are written to `GitHub Actions Job Summaries`.

--- a/sandbox/Benchmark/TestData/TestDataGenerator.cs
+++ b/sandbox/Benchmark/TestData/TestDataGenerator.cs
@@ -17,7 +17,7 @@ public static class TestDataGenerator
         return array;
     }
 
-    public static T GetValue<T>(int length)
+    public static T GetValue<T>()
         where T : notnull
     {
         return GenerateRandomValue<T>()!;


### PR DESCRIPTION
This PR intended to fix benchmark reports issues on [latest benchmark](https://github.com/Cysharp/ZLinq/actions/runs/15100363106)
that some tables are not correctly shown as table format.

**What's changed in this PR**
- Add code to exclude `reports.md` (This file is expected to be used for publishing standalone report to GitHub Pages)
- Fix header/content to show correct benchmark name when using generics.
- Remove redundant benchmark from  `ConcatBenchmark.cs`
- Adjust renamed benchmark workflow name
- Cleanup code (Remove unused parameter/fix wrong class name)