### PR TITLE
chore: Add additional benchmarks

### DIFF
--- a/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/ConsumerExtensions.UnaryOperations.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/ConsumerExtensions.UnaryOperations.cs
@@ -88,7 +88,7 @@ internal static partial class ConsumerExtensions
     #region Select
 
 #if !USE_ZLINQ_NUGET_PACKAGE || ZLINQ_1_3_1_OR_GREATER
-    // Select FromArray(Optimized)
+    // Select FromArray
     public static void Consume<T>(this ValueEnumerable<ArraySelect<T, T>, T> source, Consumer consumer)
     {
         using var e = source.Enumerator;
@@ -96,7 +96,7 @@ internal static partial class ConsumerExtensions
             consumer.Consume(in item);
     }
 
-    // Select FromArray(Optimized)
+    // Select FromList
     public static void Consume<T>(this ValueEnumerable<ListSelect<T, T>, T> source, Consumer consumer)
     {
         using var e = source.Enumerator;
@@ -281,16 +281,50 @@ internal static partial class ConsumerExtensions
             consumer.Consume(in item);
     }
 
+    #region where
+
 #if !USE_ZLINQ_NUGET_PACKAGE || ZLINQ_1_3_1_OR_GREATER
-    // Where FromArray (Optimized)
+    // Where FromArray
     public static void Consume<T>(this ValueEnumerable<ArrayWhere<T>, T> source, Consumer consumer)
     {
         using var e = source.Enumerator;
         while (e.TryGetNext(out var item))
             consumer.Consume(in item);
     }
+
+    // Where FromList
+    public static void Consume<T>(this ValueEnumerable<ListWhere<T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+
+    // WhereSelect FromArray
+    public static void Consume<TSource, T>(this ValueEnumerable<ArrayWhereSelect<TSource, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+
+    // WhereSelect FromList
+    public static void Consume<TSource, T>(this ValueEnumerable<ListWhereSelect<TSource, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+
+    // WhereSelect FromEnumerable
+    public static void Consume<T>(this ValueEnumerable<WhereSelect<FromEnumerable<T>, T, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
 #else
-    // Where FromArray (Optimized)
+    // Where FromArray
     public static void Consume<T>(this ValueEnumerable<WhereArray<T>, T> source, Consumer consumer)
     {
         using var e = source.Enumerator;
@@ -298,4 +332,14 @@ internal static partial class ConsumerExtensions
             consumer.Consume(in item);
     }
 #endif
+
+    // Where FromEnumerable
+    public static void Consume<T>(this ValueEnumerable<Where<FromEnumerable<T>, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
+
+    #endregion
 }

--- a/sandbox/Benchmark/Benchmarks/StringJoinBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/StringJoinBenchmark.cs
@@ -1,32 +1,27 @@
-﻿using BenchmarkDotNet.Attributes;
+﻿using Benchmark.ZLinq;
+using BenchmarkDotNet.Attributes;
 using ZLinq;
 
 namespace Benchmark;
 
-public class StringJoinBenchmark
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[GenericTypeArguments(typeof(int))]    // ValueType
+[GenericTypeArguments(typeof(string))] // ReferenceType
+public class StringJoinBenchmark<T> : EnumerableBenchmarkBase<T>
 {
-    int[] source = default!;
-
-    [GlobalSetup]
-    public void Setup()
-    {
-        source = Enumerable.Range(1, 1000)
-                           .Select(_ => Random.Shared.Next())
-                           .ToArray();
-    }
-
-    [Benchmark(Baseline = true)]
+    [Benchmark]
     [BenchmarkCategory(Categories.LINQ)]
     public void SystemLinq()
     {
-        _ = string.Join(',', source);
+        _ = string.Join(',', source.ArrayData);
     }
 
     [Benchmark]
     [BenchmarkCategory(Categories.ZLinq)]
     public void ZLinq()
     {
-        _ = source.AsValueEnumerable()
+        _ = source.ArrayData
+                  .AsValueEnumerable()
                   .JoinToString(',');
     }
 }

--- a/sandbox/Benchmark/Benchmarks/WhereBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/WhereBenchmark.cs
@@ -1,0 +1,52 @@
+﻿using Benchmark.ZLinq;
+using ZLinq;
+
+namespace Benchmark;
+
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[GenericTypeArguments(typeof(int))]    // ValueType
+[GenericTypeArguments(typeof(string))] // ReferenceType
+public class WhereBenchmark<T> : EnumerableBenchmarkBase<T>
+{
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    [BenchmarkCategory(Categories.From.Array)]
+    public void FromArray_Linq()
+    {
+        source.ArrayData
+              .Where(x => true)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    [BenchmarkCategory(Categories.From.List)]
+    public void FromList_Linq()
+    {
+        source.ListData
+              .Where(x => true)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    [BenchmarkCategory(Categories.From.Array)]
+    public void FromArray_ZLinq()
+    {
+        source.ArrayData
+              .AsValueEnumerable()
+              .Where(x => true)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    [BenchmarkCategory(Categories.From.List)]
+    public void FromList_ZLinq()
+    {
+        source.ListData
+              .AsValueEnumerable()
+              .Where(x => true)
+              .Consume(consumer);
+    }
+}

--- a/sandbox/Benchmark/Benchmarks/WhereSelectBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/WhereSelectBenchmark.cs
@@ -1,0 +1,79 @@
+﻿using Benchmark.ZLinq;
+using ZLinq;
+
+namespace Benchmark;
+
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+[GenericTypeArguments(typeof(int))]    // ValueType
+[GenericTypeArguments(typeof(string))] // ReferenceType
+public class WhereSelectBenchmark<T> : EnumerableBenchmarkBase<T>
+{
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    [BenchmarkCategory(Categories.From.Array)]
+    public void FromArray_Linq()
+    {
+        source.ArrayData
+              .Where(x => true)
+              .Select(x => x)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    [BenchmarkCategory(Categories.From.List)]
+    public void FromList_Linq()
+    {
+        source.ListData
+              .Where(x => true)
+              .Select(x => x)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    [BenchmarkCategory(Categories.From.EnumerableArray)]
+    public void FromEnumerableArray_Linq()
+    {
+        source.EnumerableArrayData
+              .Where(x => true)
+              .Select(x => x)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    [BenchmarkCategory(Categories.From.Array)]
+    public void FromArray_ZLinq()
+    {
+        source.ArrayData
+              .AsValueEnumerable()
+              .Where(x => true)
+              .Select(x => x)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    [BenchmarkCategory(Categories.From.List)]
+    public void FromList_ZLinq()
+    {
+        source.ListData
+              .AsValueEnumerable()
+              .Where(x => true)
+              .Select(x => x)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    [BenchmarkCategory(Categories.From.EnumerableArray)]
+    public void FromEnumerableArray_ZLinq()
+    {
+        source.EnumerableArrayData
+              .AsValueEnumerable()
+              .Where(x => true)
+              .Select(x => x)
+              .Consume(consumer);
+    }
+}


### PR DESCRIPTION
**What's changed in this PR**

1. Add following benchmarks.
- `WhereBenchmark<T>`  
- `WhereSelectBenchmark<T>`
2. Modify `StringJoinBenchmark.cs` to tests several data patterns (`int` and `string`)
3. Add additional Consume methods to `ConsumerExtensions.UnaryOperations.cs`

**Background**
I've confirmed perf issue that is reported by #156.
And it seems ZLinq run slower when following conditions are met.
- Using `List<T>` as data source.
- `T` is reference type. (e.g. string)
-  Running on `.NET 8`

**Benchmark Results**

### `WhereBenchmark<string>`
| Method          | Job    | N       | Mean      | Error     | StdDev    | Ratio | Allocated | Alloc Ratio |
|---------------- |------- |-------- |----------:|----------:|----------:|------:|----------:|------------:|
| FromArray_Linq  | .NET 8 | 1000000 |  7.083 ms | 0.4785 ms | 0.0262 ms |  1.00 |      51 B |        1.00 |
| FromArray_Linq  | .NET 9 | 1000000 |  6.889 ms | 0.1705 ms | 0.0093 ms |  0.97 |      49 B |        0.96 |
|                 |        |         |           |           |           |       |           |             |
| FromList_Linq   | .NET 8 | 1000000 |  9.514 ms | 0.8284 ms | 0.0454 ms |  1.00 |      78 B |        1.00 |
| FromList_Linq   | .NET 9 | 1000000 |  8.361 ms | 1.7591 ms | 0.0964 ms |  0.88 |      74 B |        0.95 |
|                 |        |         |           |           |           |       |           |             |
| FromArray_ZLinq | .NET 8 | 1000000 |  4.573 ms | 0.4927 ms | 0.0270 ms |  1.00 |       3 B |        1.00 |
| FromArray_ZLinq | .NET 9 | 1000000 |  2.905 ms | 0.7514 ms | 0.0412 ms |  0.64 |         - |        0.00 |
|                 |        |         |           |           |           |       |           |             |
| FromList_ZLinq  | .NET 8 | 1000000 | 14.042 ms | 1.4564 ms | 0.0798 ms |  1.00 |       6 B |        1.00 |
| FromList_ZLinq  | .NET 9 | 1000000 |  3.138 ms | 0.5296 ms | 0.0290 ms |  0.22 |       2 B |        0.33 |

`FromList_ZLinq` benchmark on .NET 8 takes 1.5x times than LINQ.
It's not occurred when T is value type. And running .NET 9 benchmarks. 
