### PR TITLE
Add ImmutableHashSet.AsValueEnumerable

### DIFF
--- a/src/ZLinq/Linq/Contains.cs
+++ b/src/ZLinq/Linq/Contains.cs
@@ -35,6 +35,15 @@ namespace ZLinq
             return innerCollection.Contains(value);
         }
 
+#if NET8_0_OR_GREATER
+
+        public static Boolean Contains<TSource>(this ValueEnumerable<FromImmutableHashSet<TSource>, TSource> source, TSource value)
+        {
+            var innerCollection = source.Enumerator.GetSource();
+            return innerCollection.Contains(value);
+        }
+#endif
+
         public static Boolean Contains<TEnumerator, TSource>(this ValueEnumerable<TEnumerator, TSource> source, TSource value)
     where TEnumerator : struct, IValueEnumerator<TSource>
 #if NET9_0_OR_GREATER

--- a/tests/ZLinq.Tests/Linq/AsValueEnumerableTest.cs
+++ b/tests/ZLinq.Tests/Linq/AsValueEnumerableTest.cs
@@ -381,6 +381,38 @@ namespace ZLinq.Tests.Linq
             var resultArray = result.ToArray();
             resultArray.ShouldBe(source.ToArray());
         }
+
+        [Fact]
+        public void FromImmutableHashSet_BasicFunctionality()
+        {
+            // Arrange
+            var source = ImmutableHashSet.Create(5, 2, 1, 4, 3);
+
+            // Act
+            var result = source.AsValueEnumerable();
+
+            // Assert
+            result.TryGetNonEnumeratedCount(out var count).ShouldBeTrue();
+            count.ShouldBe(source.Count);
+
+            result.TryGetSpan(out var span).ShouldBeFalse();
+
+            var resultArray = result.ToArray();
+            resultArray.ShouldBe(new[] { 1, 2, 3, 4, 5 }); // SortedSet should be ordered
+        }
+
+        [Fact]
+        public void FromImmutableHashSet_ContainsOptimization()
+        {
+            // Arrange
+            var source = ImmutableHashSet.Create(5, 2, 1, 4, 3);
+            var result = source.AsValueEnumerable();
+
+            // Act & Assert
+            result.Contains(3).ShouldBeTrue();
+            result.Contains(6).ShouldBeFalse();
+        }
+
 #endif
 
 #if NET9_0_OR_GREATER


### PR DESCRIPTION
This PR adds `AsValueEnumerable` support for `ImmutableHashSet<T>`, following the same pattern as implemented in v1.4.10.