### PR TITLE
chore: Update package dependencies

### DIFF
--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -30,7 +30,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36127.1" />
     <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.UserMarks" Version="18.0.36127.1" />
     <PackageReference Include="Kokuban" Version="0.2.0" />

--- a/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/BaseBenchmarkConfig.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/BaseBenchmarkConfig.cs
@@ -3,6 +3,7 @@ using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Exporters;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Order;
 using BenchmarkDotNet.Reports;
 
 namespace Benchmark;
@@ -16,6 +17,8 @@ public abstract class BaseBenchmarkConfig : ManualConfig
     {
         WithSummaryStyle(SummaryStyle.Default
                                      .WithMaxParameterColumnWidth(40)); // Default: 20 chars
+
+        WithOrderer(new DefaultOrderer(jobOrderPolicy: JobOrderPolicy.Numeric));
 
         // Set default options that based on DefaultConfig.
         WithUnionRule(DefaultConfig.Instance.UnionRule);
@@ -32,10 +35,13 @@ public abstract class BaseBenchmarkConfig : ManualConfig
         // WithOptions(ConfigOptions.GenerateMSBuildBinLog);
     }
 
-    // Use ShortRun as base Job.(LaunchCount=1  TargetCount=3 WarmupCount = 3)
+    // Use Job.ShortRun based settings (LaunchCount=1  TargetCount=3 WarmupCount = 3)
     protected virtual Job GetBaseJobConfig() =>
-        Job.ShortRun
-           .WithStrategy(RunStrategy.Throughput) // Use default RunStrategy
+        Job.Default
+           .WithLaunchCount(1)
+           .WithWarmupCount(3)
+           .WithIterationCount(3) // This setting might be adjusted when benchmark iteration time is smaller than min IterationTime settings (Default: 500ms)
+           .WithStrategy(RunStrategy.Throughput) // Explicitly specify RunStrategy (it show `Default` when it's not explicitly specified)
            .DontEnforcePowerPlan();
 
     /// <summary>

--- a/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/NuGetVersionsBenchmarkConfig.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/NuGetVersionsBenchmarkConfig.cs
@@ -107,11 +107,11 @@ public class NuGetVersionsBenchmarkConfig : BaseBenchmarkConfig
         const string url = "https://api.nuget.org/v3-flatcontainer/zlinq/index.json"; // Must be lower-case.
         var json = new HttpClient().GetStringAsync(url).GetAwaiter().GetResult();
 
-        // Note: Uncomment following line when comparing all NuGet package versions performance.
-        // return versions;
-
         var node = JsonNode.Parse(json)!;
         var versions = node["versions"]!.AsArray().GetValues<string>().ToArray();
+
+        // Note: Uncomment following line when comparing all NuGet package versions performance.
+        // return versions.Where(x => Version.Parse(x).Major >= 1);
 
         bool isRunningOnGitHubActions = Environment.GetEnvironmentVariable("GITHUB_ACTIONS") == "true";
         return isRunningOnGitHubActions

--- a/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/SummariesExtensions.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/SummariesExtensions.cs
@@ -154,7 +154,6 @@ public static partial class SummariesExtensions
         {
             logger.WriteLine(Chalk.Red[$"Error: {benchmarksWithTroubles.Length} benchmarks faled to run."]);
             logger.WriteLine();
-
             // Print clickable log file link.
             logger.WriteLine(Chalk.Red[$"For detailed error messages. Confirm the output log file."]);
             logger.Write(Chalk.Red["  " + ToClickableLink(logFilePath)]);
@@ -169,7 +168,7 @@ public static partial class SummariesExtensions
 
         return config.GetExporters()
                      .OfType<ExporterBase>()
-                     .Select(x => GetArtifactFullName(x, summary))
+                     .Select(x => x.GetArtifactFullName(summary))
                      .ToArray();
     }
 
@@ -185,9 +184,4 @@ public static partial class SummariesExtensions
         caption ??= url;
         return $"{ESC}]8;;{url}{ESC}\\{caption}{ESC}]8;;{ESC}\\";
     }
-
-    // Currently this API is not publicky exposed.
-    // See: https://github.com/dotnet/BenchmarkDotNet/issues/2619
-    [UnsafeAccessor(UnsafeAccessorKind.Method, Name = nameof(GetArtifactFullName))]
-    private static extern string GetArtifactFullName(ExporterBase target, Summary summary);
 }

--- a/sandbox/Benchmark/Properties/launchSettings.json
+++ b/sandbox/Benchmark/Properties/launchSettings.json
@@ -9,7 +9,7 @@
       // 2. InProcess
       // 3. Test (or InProcessMonitoring)
       // 4. ColdStart
-      // 5. TargeFrameworks
+      // 5. TargetFrameworks
       // 6. NuGetVersions
       // 7. SystemLinq
       //

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.UserMarks" Version="17.14.36021.1" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.UserMarks" Version="18.0.36127.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ZLinq.Json/ZLinq.Json.csproj
+++ b/src/ZLinq.Json/ZLinq.Json.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
-    <PackageReference Include="System.Text.Json" Version="9.0.5" />
+    <PackageReference Include="System.Text.Json" Version="9.0.6" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/ZLinq/ZLinq.csproj
+++ b/src/ZLinq/ZLinq.csproj
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.6" />
     <PackageReference Include="System.Buffers" Version="4.6.1" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />

--- a/tests/System.Linq.Tests/System.Linq.Tests.csproj
+++ b/tests/System.Linq.Tests/System.Linq.Tests.csproj
@@ -33,7 +33,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3" Version="2.0.1" />
+    <PackageReference Include="xunit.v3" Version="2.0.3" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 

--- a/tests/ZLinq.Tests/ZLinq.Tests.csproj
+++ b/tests/ZLinq.Tests/ZLinq.Tests.csproj
@@ -28,11 +28,11 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="xunit.v3" Version="1.1.0" />
+    <PackageReference Include="xunit.v3" Version="[1.1.0]" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="xunit.v3" Version="2.0.2" />
+    <PackageReference Include="xunit.v3" Version="2.0.3" />
   </ItemGroup>
 
 
@@ -61,9 +61,17 @@
   </ItemGroup>
 
   <!-- I don't know why but my environemnts(VS2022) still needs this for run test in Test Explorer -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.2">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="[17.13.0]" Condition="'$(TargetFramework)' == 'net6.0'"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="[3.0.2]">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"   Condition="'$(TargetFramework)' != 'net6.0'"/>
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This PR update packages dependencies and fix issue #176 

**What's changed in this PR**
1. Update package dependencies that are listed by `dotnet package list --outdated` command.
2. Update `System.Linq.Tests` project dependencies
3. Update BechmarkDotNet package related codes.
3.1. `BaseBenchmarkConfig.cs`: Modify code to use `Job.Default` instead of `Job.ShortJob`. (Because ShortJob overwrite JobId. and suppress auto JobId generation. and cause diffs when comparing diffs)
3.2. `SummariesExtensions.cs`: Modify code to call GetArtifactFullName directly.
 