### PR TITLE
Improved the speed of `Shuffle()`

### DIFF
--- a/src/ZLinq/Internal/RandomShared.cs
+++ b/src/ZLinq/Internal/RandomShared.cs
@@ -1,4 +1,6 @@
-﻿using System.Security.Cryptography;
+﻿using System.Buffers;
+using System.Numerics;
+using System.Security.Cryptography;
 
 namespace ZLinq.Internal;
 
@@ -6,75 +8,237 @@ internal static class RandomShared
 {
     public static void Shuffle<T>(Span<T> span)
     {
-#if NET8_0_OR_GREATER
-        Random.Shared.Shuffle(span);
-#else
-        Shared.Value.Shuffle(span);
-#endif
+        Shared.Shuffle(span);
     }
 
     public static void PartialShuffle<T>(Span<T> span, int count)
     {
-#if NET8_0_OR_GREATER
-        Random.Shared.PartialShuffle(span, count);
+        if (count >= span.Length)
+        {
+            Shared.Shuffle(span);
+        }
+        else
+        {
+            Shared.PartialShuffle(span, count);
+        }
+    }
+
+    internal sealed class Xoshiro256StarStar
+    {
+        private ulong _s0, _s1, _s2, _s3;
+
+        public Xoshiro256StarStar()
+        {
+#if NETSTANDARD2_1_OR_GREATER
+            var span = (stackalloc ulong[4]);
+            do
+            {
+                RandomNumberGenerator.Fill(MemoryMarshal.AsBytes(span));
+                _s0 = span[0];
+                _s1 = span[1];
+                _s2 = span[2];
+                _s3 = span[3];
+            } while (_s0 == 0 && _s1 == 0 && _s2 == 0 && _s3 == 0);
 #else
-        Shared.Value.PartialShuffle(span, count);
-#endif
-    }
-
-#if !NET8_0_OR_GREATER
-
-    private static ThreadLocal<Random> Shared = new ThreadLocal<Random>(() =>
-    {
-        using (var rng = new RNGCryptoServiceProvider())
-        {
-            var buffer = new byte[sizeof(int)];
-            rng.GetBytes(buffer);
-            var seed = BitConverter.ToInt32(buffer, 0);
-            return new Random(seed);
-        }
-    });
-
-    static void Shuffle<T>(this Random random, Span<T> values)
-    {
-        int n = values.Length;
-
-        for (int i = 0; i < n - 1; i++)
-        {
-            int j = random.Next(i, n);
-
-            if (j != i)
+            var array = ArrayPool<byte>.Shared.Rent(32);
+            using var rng = RandomNumberGenerator.Create();
+            do
             {
-                T temp = values[i];
-                values[i] = values[j];
-                values[j] = temp;
+                rng.GetBytes(array);
+                var ulongSpan = MemoryMarshal.Cast<byte, ulong>(array);
+                _s3 = ulongSpan[3];
+                _s0 = ulongSpan[0];
+                _s1 = ulongSpan[1];
+                _s2 = ulongSpan[2];
+            } while (_s0 == 0 && _s1 == 0 && _s2 == 0 && _s3 == 0);
+#endif
+        }
+
+        public ulong NextUInt64()
+        {
+            ulong s0 = _s0;
+            ulong s1 = _s1;
+            ulong s2 = _s2;
+            ulong s3 = _s3;
+
+#if NETCOREAPP3_0_OR_GREATER
+            ulong result = BitOperations.RotateLeft(s1 * 5, 7) * 9;
+#else
+            ulong result = s1 * 5;
+            result = s1 << 7 ^ s1 >> -7;
+            result *= 9;
+#endif
+            ulong t = s1 << 17;
+
+            s2 ^= s0;
+            s3 ^= s1;
+            s1 ^= s2;
+            s0 ^= s3;
+
+            s2 ^= t;
+
+#if NETCOREAPP3_0_OR_GREATER
+            s3 = BitOperations.RotateLeft(s3, 45);
+#else
+            s3 = s3 << 45 ^ s3 >> -45;
+#endif
+
+            _s0 = s0;
+            _s1 = s1;
+            _s2 = s2;
+            _s3 = s3;
+
+            return result;
+        }
+
+        private static ulong BigMul(ulong a, ulong b, out ulong lo)
+        {
+#if NET5_0_OR_GREATER
+            return Math.BigMul(a, b, out lo);
+#else
+            uint alo = (uint)a;
+            uint ahi = (uint)(a >> 32);
+            uint blo = (uint)b;
+            uint bhi = (uint)(b >> 32);
+
+            ulong mulo = (ulong)alo * blo;
+            ulong mid1 = (ulong)ahi * blo;
+            ulong mid2 = (ulong)alo * bhi;
+            ulong muhi = (ulong)ahi * bhi;
+
+            lo = mulo + (mid1 << 32) + (mid2 >> 32);
+            return muhi + (mid1 >> 32) + (mid2 >> 32) + (((mid1 & ~0u) + (mid2 & ~0u) + (mulo >> 32)) >> 32);
+#endif
+        }
+
+        public ulong NextUInt64(ulong maxExclusive)
+        {
+            ulong r = NextUInt64();
+            ulong rhi = BigMul(r, maxExclusive, out ulong rlo);
+
+            if (rlo < maxExclusive)
+            {
+                ulong mod = (0 - maxExclusive) % maxExclusive;
+                while (rlo < mod)
+                {
+                    r = NextUInt64();
+                    rhi = BigMul(r, maxExclusive, out rlo);
+                }
+            }
+
+            return rhi;
+        }
+
+        // for details on the algorithm, see https://github.com/dotnet/runtime/pull/111015
+        public void Shuffle<T>(Span<T> values)
+        {
+            ulong bound = 2432902008176640000;
+
+            int nextIndex = Math.Min(20, values.Length);
+
+            for (int i = 1; i < values.Length;)
+            {
+                ulong r = NextUInt64();
+                ulong rbound = r * bound;
+                if (rbound > 0 - bound)
+                {
+                    ulong sum, carry;
+                    do
+                    {
+                        ulong t = NextUInt64();
+                        ulong thi = BigMul(t, bound, out ulong tlo);
+                        sum = rbound + thi;
+                        carry = sum < rbound ? 1ul : 0ul;
+                        rbound = tlo;
+                    } while (sum == ~0ul);
+                    r += carry;
+                }
+
+                for (int m = i; m < nextIndex; m++)
+                {
+                    int index = (int)BigMul(r, (ulong)(m + 1), out r);
+
+                    T temp = values[m];
+                    values[m] = values[index];
+                    values[index] = temp;
+                }
+
+                i = nextIndex;
+
+                bound = (ulong)(i + 1);
+                for (nextIndex = i + 1; nextIndex < values.Length; nextIndex++)
+                {
+                    if (BigMul(bound, (ulong)(nextIndex + 1), out var newbound) == 0)
+                    {
+                        bound = newbound;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+        public void PartialShuffle<T>(Span<T> values, int count)
+        {
+            count = Math.Min(count, values.Length);
+
+            for (int i = 0; i < count;)
+            {
+                ulong bound = (ulong)(values.Length - i);
+                int nextIndex;
+                if (bound <= 20)
+                {
+                    bound = 2432902008176640000;
+                    nextIndex = count;
+                }
+                else
+                {
+                    for (nextIndex = i + 1; nextIndex < count; nextIndex++)
+                    {
+                        if (BigMul(bound, (ulong)(values.Length - nextIndex), out var newbound) == 0)
+                        {
+                            bound = newbound;
+                        }
+                        else
+                        {
+                            break;
+                        }
+                    }
+                }
+
+                ulong r = NextUInt64();
+                ulong rbound = r * bound;
+                if (rbound > 0 - bound)
+                {
+                    ulong sum, carry;
+                    do
+                    {
+                        ulong t = NextUInt64();
+                        ulong thi = BigMul(t, bound, out ulong tlo);
+                        sum = rbound + thi;
+                        carry = sum < rbound ? 1ul : 0ul;
+                        rbound = tlo;
+                    } while (sum == ~0ul);
+                    r += carry;
+                }
+
+                for (int m = i; m < nextIndex; m++)
+                {
+                    int index = m + (int)BigMul(r, (ulong)(values.Length - m), out r);
+
+                    T temp = values[m];
+                    values[m] = values[index];
+                    values[index] = temp;
+                }
+
+                i = nextIndex;
             }
         }
     }
 
-#endif
-
-    static void PartialShuffle<T>(this Random random, Span<T> values, int count)
-    {
-        if (count <= 0) return;
-
-        int n = Math.Min(values.Length, count);
-
-        if (n == values.Length)
-        {
-            n--;  // exclude last item, otherwise includes n
-        }
-
-        for (int i = 0; i < n; i++) // < n
-        {
-            int j = random.Next(i, values.Length); // shuffle based length
-
-            if (j != i)
-            {
-                T temp = values[i];
-                values[i] = values[j];
-                values[j] = temp;
-            }
-        }
-    }
+    [ThreadStatic]
+    private static Xoshiro256StarStar? s_Shared;
+    private static Xoshiro256StarStar Shared => s_Shared ??= new();
 }


### PR DESCRIPTION
## Summary

Improved the speed of `Shuffle()` by ～ 2.6x.

## Benchmark

```cs
public static int Main(string[] args)
{
    BenchmarkRunner.Run<ShuffleBench>(args: args);
    return 0;
}
```

```
BenchmarkDotNet v0.15.2, Windows 11 (10.0.26100.4349/24H2/2024Update/HudsonValley)
12th Gen Intel Core i7-12700F 2.10GHz, 1 CPU, 20 logical and 12 physical cores
.NET SDK 10.0.100-preview.5.25277.114
  [Host]     : .NET 10.0.0 (10.0.25.27814), X64 RyuJIT AVX2
  DefaultJob : .NET 10.0.0 (10.0.25.27814), X64 RyuJIT AVX2
```

Before:

| Method          | N      | M      | Mean          | Error         | StdDev         | Median        |
|---------------- |------- |------- |--------------:|--------------:|---------------:|--------------:|
| ShuffleTakeLinq | 1000   | 10     |   4,390.91 ns |    256.749 ns |     719.953 ns |   4,670.29 ns |
| ShuffleTakeLinq | 1000   | 100    |   7,343.62 ns |    345.180 ns |     984.817 ns |   7,719.69 ns |
| ShuffleTakeLinq | 1000   | 1000   |   4,071.74 ns |     53.117 ns |      41.470 ns |   4,061.72 ns |
| ShuffleTakeLinq | 1000   | 100000 |   4,117.56 ns |     33.945 ns |      26.502 ns |   4,124.88 ns |
| ShuffleTakeLinq | 100000 | 10     | 327,208.70 ns | 16,008.675 ns |  47,201.941 ns | 343,945.87 ns |
| ShuffleTakeLinq | 100000 | 100    | 242,080.14 ns | 26,929.140 ns |  79,401.182 ns | 186,970.47 ns |
| ShuffleTakeLinq | 100000 | 1000   | 229,417.80 ns |  3,317.590 ns |   8,200.262 ns | 227,635.45 ns |
| ShuffleTakeLinq | 100000 | 100000 | 630,294.22 ns | 65,411.969 ns | 192,868.680 ns | 512,984.18 ns |
|                 |        |        |               |               |                |               |
| ShuffleTakeZL   | 1000   | 10     |      82.69 ns |      0.704 ns |       0.658 ns |      82.69 ns |
| ShuffleTakeZL   | 1000   | 100    |     690.60 ns |     36.599 ns |     107.914 ns |     724.73 ns |
| ShuffleTakeZL   | 1000   | 1000   |   6,037.47 ns |    369.983 ns |   1,090.904 ns |   6,394.99 ns |
| ShuffleTakeZL   | 1000   | 100000 |   5,672.11 ns |    329.154 ns |     965.351 ns |   5,971.55 ns |
| ShuffleTakeZL   | 100000 | 10     |  11,081.71 ns |    485.221 ns |   1,344.546 ns |  11,431.81 ns |
| ShuffleTakeZL   | 100000 | 100    |  11,825.45 ns |    508.941 ns |   1,418.723 ns |  12,206.31 ns |
| ShuffleTakeZL   | 100000 | 1000   |  17,106.84 ns |    962.291 ns |   2,760.994 ns |  18,068.87 ns |
| ShuffleTakeZL   | 100000 | 100000 | 258,360.04 ns |  2,983.644 ns |   2,329.433 ns | 258,010.50 ns |

After:

| Method          | N      | M      | Mean          | Error        | StdDev       | Median        |
|---------------- |------- |------- |--------------:|-------------:|-------------:|--------------:|
| ShuffleTakeLinq | 1000   | 10     |   4,398.77 ns |   237.561 ns |   692.976 ns |   4,664.29 ns |
| ShuffleTakeLinq | 1000   | 100    |   6,158.41 ns |   531.077 ns | 1,565.892 ns |   5,631.29 ns |
| ShuffleTakeLinq | 1000   | 1000   |   4,043.41 ns |    20.010 ns |    18.717 ns |   4,038.13 ns |
| ShuffleTakeLinq | 1000   | 100000 |   4,092.15 ns |    33.186 ns |    31.042 ns |   4,083.33 ns |
| ShuffleTakeLinq | 100000 | 10     | 176,712.14 ns | 1,863.189 ns | 1,742.828 ns | 176,204.79 ns |
| ShuffleTakeLinq | 100000 | 100    | 185,034.66 ns |   846.611 ns |   750.498 ns | 184,857.79 ns |
| ShuffleTakeLinq | 100000 | 1000   | 227,024.46 ns | 1,310.362 ns | 1,225.713 ns | 226,563.96 ns |
| ShuffleTakeLinq | 100000 | 100000 | 491,479.11 ns | 4,557.176 ns | 4,262.785 ns | 490,562.30 ns |
|                 |        |        |               |              |              |               |
| ShuffleTakeZL   | 1000   | 10     |      81.37 ns |     1.307 ns |     1.222 ns |      81.69 ns |
| ShuffleTakeZL   | 1000   | 100    |     265.07 ns |     2.620 ns |     2.451 ns |     264.80 ns |
| ShuffleTakeZL   | 1000   | 1000   |   1,921.05 ns |    15.893 ns |    14.089 ns |   1,919.34 ns |
| ShuffleTakeZL   | 1000   | 100000 |   1,982.34 ns |    18.037 ns |    16.871 ns |   1,980.04 ns |
| ShuffleTakeZL   | 100000 | 10     |   6,535.99 ns |    49.108 ns |    45.936 ns |   6,525.33 ns |
| ShuffleTakeZL   | 100000 | 100    |   6,717.00 ns |    40.599 ns |    35.990 ns |   6,708.83 ns |
| ShuffleTakeZL   | 100000 | 1000   |   8,749.90 ns |    77.955 ns |    72.919 ns |   8,749.02 ns |
| ShuffleTakeZL   | 100000 | 100000 | 225,266.30 ns | 1,117.694 ns |   990.806 ns | 225,655.81 ns |

## Details 

Algorithm details:

* https://github.com/dotnet/runtime/pull/111015
* (Japanese) https://andantesoft.hatenablog.com/entry/2024/12/30/183006

I implemented the PRNG without relying on `System.Random` because the algorithm requires `NextUInt64()`.
The algorithm of the PRNG itself has not changed. It uses `xoshiro256**`, the same as the current .NET implementation.
In environments with older implementations of `System.Random`, such as Unity, this may help speed things up even more.

