### PR TITLE
chore: Add .NET10 benchmark for CI and .NET 10 Preview installed environment

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -18,6 +18,13 @@ on:
         type: string
         description: Specify benchmark filter text (e,g. Benchmark.ReadMeBenchmark*)
         default: '*'
+      framework:
+        type: choice
+        description: Specify target framework for benchmark
+        default: net9.0
+        options:
+          - net9.0
+          - net10.0
 
 jobs:
   benchmark:
@@ -28,11 +35,17 @@ jobs:
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+
+      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+        if: ${{ inputs.framework }} == 'net10.0'
+        with:
+          dotnet-version: 10.0.x
+
       - run: dotnet build -c Release
 
       - name: Run Benchmarks
         working-directory: sandbox/Benchmark
-        run: dotnet run -c Release --framework net9.0 --no-build --no-launch-profile -- --filter "${{ inputs.filter }}" -- ${{ inputs.config }}
+        run: dotnet run -c Release --framework ${{ inputs.framework }} --no-build --no-launch-profile -- --filter "${{ inputs.filter }}" -- ${{ inputs.config }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 #v4.6.1

--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -16,8 +16,8 @@
     <DefineConstants>$(DefineConstants);DIAGHUB_ENABLE_TRACE_SYSTEM</DefineConstants>
   </PropertyGroup>
 
-  <!-- Add .NET 10 support when running build inside Visual Studio Preview-->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != '' AND $(VisualStudioDir.Contains('Preview'))">
+  <!-- Add .NET 10 support if .NET 10 or later version of MSBuild is used. -->
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','10.0'))">
     <TargetFrameworks>net10.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 

--- a/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/BaseBenchmarkConfig.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/BaseBenchmarkConfig.cs
@@ -35,7 +35,7 @@ public abstract class BaseBenchmarkConfig : ManualConfig
         // WithOptions(ConfigOptions.GenerateMSBuildBinLog);
     }
 
-    // Use Job.ShortRun based settings (LaunchCount=1  TargetCount=3 WarmupCount = 3)
+    // Use Job.ShortRun based settings (LaunchCount=1 IterationCount=3 WarmupCount = 3)
     protected virtual Job GetBaseJobConfig() =>
         Job.Default
            .WithLaunchCount(1)

--- a/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/SystemLinqBenchmarkConfig.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/SystemLinqBenchmarkConfig.cs
@@ -25,12 +25,10 @@ public class SystemLinqBenchmarkConfig : BaseBenchmarkConfig
 
         // Add job for ZLinq benchmarks.
         AddJob(baseJobConfig.WithToolchain(Constants.DefaultToolchain)
-                            .WithId(Options.HasFlag(ConfigOptions.KeepBenchmarkFiles)
-                                      ? $"{ZLinqJobId}_" // Needs extra suffix to avoid conflict assembly name. // TODO: It can be removed after BenchmarkDotNet v1.40.1 is release.
-                                      : ZLinqJobId));
+                            .WithId(ZLinqJobId));
 
         // Show summary with declared order (Default: execution order)
-        WithOrderer(new DefaultOrderer(summaryOrderPolicy: SummaryOrderPolicy.Declared));
+        WithOrderer(new DefaultOrderer(summaryOrderPolicy: SummaryOrderPolicy.Declared, jobOrderPolicy: JobOrderPolicy.Numeric));
 
         // Configure additional settings.
         AddConfigurations();

--- a/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/TargetFrameworksBenchmarkConfig.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/BenchmarkConfigs/TargetFrameworksBenchmarkConfig.cs
@@ -20,8 +20,10 @@ public class TargetFrameworksBenchmarkConfig : BaseBenchmarkConfig
         // Note: Run benchmark with `-runtimes` parameters.
         AddJob(baseJobConfig.WithToolchain(CsProjCoreToolchain.NetCoreApp80).WithId(".NET 8").AsBaseline());
         AddJob(baseJobConfig.WithToolchain(CsProjCoreToolchain.NetCoreApp90).WithId(".NET 9"));
-        // TODO: Currently BenchmarkDotNet don't support .NET10
-        //AddJob(baseJobConfig.WithToolchain(CsProjCoreToolchain.NetCoreApp10_0).WithId(".NET 10"));
+
+#if NET10_0_OR_GREATER
+        AddJob(baseJobConfig.WithToolchain(CsProjCoreToolchain.NetCoreApp10_0).WithId(".NET 10"));
+#endif
 
         // Configure additional settings.
         AddConfigurations();

--- a/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/ConsumerExtensions.UnaryOperations.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/ExtensionMethods/ConsumerExtensions.UnaryOperations.cs
@@ -350,4 +350,12 @@ internal static partial class ConsumerExtensions
     }
 
     #endregion
+
+    // ShuffleSkipTake FromArray
+    public static void Consume<T>(this ValueEnumerable<ShuffleSkipTake<FromArray<T>, T>, T> source, Consumer consumer)
+    {
+        using var e = source.Enumerator;
+        while (e.TryGetNext(out var item))
+            consumer.Consume(in item);
+    }
 }

--- a/sandbox/Benchmark/Benchmarks/ZLinq/MicroBenchmarks/UnaryOperations/ShuffleBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/ZLinq/MicroBenchmarks/UnaryOperations/ShuffleBenchmark.cs
@@ -4,9 +4,11 @@ namespace Benchmark.ZLinq;
 
 #if !USE_SYSTEM_LINQ || NET10_0_OR_GREATER
 [BenchmarkCategory(Categories.Methods.Shuffle)]
-[BenchmarkCategory(Categories.Filters.NET10_0_OR_GREATER)]
+[BenchmarkCategory(Categories.Filters.SystemLinq_NET10_0_OR_GREATER)]
 public partial class ShuffleBenchmark<T> : EnumerableBenchmarkBase_WithBasicTypes<T>
 {
+    private readonly int TakeCount = 100;
+
     [Benchmark]
     [BenchmarkCategory(Categories.From.Default)]
     public void Shuffle()
@@ -14,6 +16,28 @@ public partial class ShuffleBenchmark<T> : EnumerableBenchmarkBase_WithBasicType
         source.Default
               .AsValueEnumerable()
               .Shuffle()
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.From.Default)]
+    public void ShuffleTake()
+    {
+        source.Default
+              .AsValueEnumerable()
+              .Shuffle()
+              .Take(TakeCount)
+              .Consume(consumer);
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.From.Default)]
+    public void ShuffleTakeLast()
+    {
+        source.Default
+              .AsValueEnumerable()
+              .Shuffle()
+              .Take(TakeCount)
               .Consume(consumer);
     }
 }

--- a/sandbox/Benchmark/Constants.cs
+++ b/sandbox/Benchmark/Constants.cs
@@ -5,7 +5,11 @@ namespace Benchmark;
 
 public static class Constants
 {
+#if NET10_0_OR_GREATER
+    public static readonly IToolchain DefaultToolchain = CsProjCoreToolchain.NetCoreApp10_0;
+#else
     public static readonly IToolchain DefaultToolchain = CsProjCoreToolchain.NetCoreApp90;
+#endif
 
     public static class DefineConstants
     {

--- a/sandbox/Benchmark/README.md
+++ b/sandbox/Benchmark/README.md
@@ -1,4 +1,4 @@
-﻿## How to run benchmarks
+## How to run benchmarks
 
 ### 1. Visual Studio
 
@@ -29,9 +29,15 @@ gh workflow run benchmark.yaml --repo Cysharp/ZLinq --ref $branchName
 # Run benchmark with `Default` config with benchmark filter
 gh workflow run benchmark.yaml --repo Cysharp/ZLinq --ref $branchName -f filter=Benchmark.ReadMeBenchmark*
 
+# Run benchmark with `TargetFrameworks` config
+gh workflow run benchmark.yaml --repo Cysharp/ZLinq --ref $branchName -f config=TargetFrameworks
+
 # Run benchmark with `SystemLinq` config
 gh workflow run benchmark.yaml --repo Cysharp/ZLinq --ref $branchName -f config=SystemLinq
 ```
+
+> [!NOTE]
+> When running .NET 10 benchmarks. It need to add `-f framework=net10.0` input parameter
 
 Benchmark results are written to `GitHub Actions Job Summaries`.
 And archived as ZIP artifacts.

--- a/tests/System.Linq.Tests/System.Linq.Tests.csproj
+++ b/tests/System.Linq.Tests/System.Linq.Tests.csproj
@@ -21,9 +21,9 @@
     <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
-  <!-- Add .NET 10 support when running build inside Visual Studio Preview-->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != '' AND $(VisualStudioDir.Contains('Preview'))">
-    <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
+  <!-- Add .NET 10 support if .NET 10 or later version of MSBuild is used. -->
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','10.0'))">
+    <TargetFrameworks>net10.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tests/ZLinq.Tests/ZLinq.Tests.csproj
+++ b/tests/ZLinq.Tests/ZLinq.Tests.csproj
@@ -22,9 +22,9 @@
     <TargetFrameworks>$(TargetFrameworks);net48</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- Add .NET 10 support when running build inside Visual Studio Preview-->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != '' AND $(VisualStudioDir.Contains('Preview'))">
-    <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
+  <!-- Add .NET 10 support if .NET 10 or later version of MSBuild is used. -->
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','10.0'))">
+    <TargetFrameworks>net10.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
This PR intended to add support to run .NET 10 benchmarks on CI.

Previously, .NET 10 target framework is used when building project on Visual Studio **Preview** version.
This PR change this condition to when building project with **,NET 10 version** of MsBuild.

> ![NOTE]
> Non-Preview version of Visual Studio is not affected by this changes.
> Because  `Use previews of the .NET SDK` experimental feature is not enabled by default.

*What's changed in this PR**

1. Modify `benchmarks.yaml`.
1.1. Add `framework` input. And pass parameter to `dotnet run --framework`.
1.2. Add optional steps to install .NET 10 SDK 
2. Modify benchmark projects to use `net10.0` if MSBuild running on .NET 10
3. Add Shuffle benchmarks for SystemLinq benchmarks
4. Modify other benchmark related settings/typo