### PR TITLE
chore: Add benchmark steps to rewrite benchmar report URL of README.md

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -29,7 +29,7 @@ on:
 jobs:
   benchmark:
     permissions:
-      contents: read
+      contents: write
     runs-on: ubuntu-24.04
     timeout-minutes: 360 # Default: 360 minutes
     steps:
@@ -67,9 +67,27 @@ jobs:
             $title = $title.Replace('_Double_', '&lt;double&gt;')
 
             $content = Get-Content $item.FullName -Raw
-            $tableContent = $content.Substring($content.IndexOf('|'))                        
+            $tableContent = $content.Substring($content.IndexOf('|'))
             $tableContent.Replace('<', '&lt;').Replace('>', '&gt;')
 
             Write-Output ('## {0}' -f $title)  >> $env:GITHUB_STEP_SUMMARY
             Write-Output $tableContent         >> $env:GITHUB_STEP_SUMMARY
           }
+
+      - name: Update README.md benchmark report link
+        if: ${{ context.repo.owner == 'Cysharp' && github.ref_name == 'main' && inputs.config == 'Default' && inputs.filter == '*' }}
+        shell: pwsh
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+
+          $md = Get-Content README.md -Raw
+          $md = [regex]::Replace($md, 'https://github.com/Cysharp/ZLinq/actions/runs/([\d]+)', 
+                                      'https://github.com/Cysharp/ZLinq/actions/runs/${{ github.run_id }}')
+          Set-Content -Path README.md -Value $md -Encoding utf8NoBOM
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add README.md
+          git commit -m 'ci: update benchmark report link'
+          git push

--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - "main"
+    paths-ignore:
+      - README.md
   pull_request:
     branches:
       - "main"


### PR DESCRIPTION
This PR add feature to update `README.md`'s benchmark report URL automatically when.

**What's changed in this PR**
1. Add benchmark step to update benchmark report URL.
2. Add `paths-ignore:` settings to `build-debug.yaml` to ignore README.md update.
