### PR TITLE
chore: Fix failed ci workflows

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -75,7 +75,7 @@ jobs:
           }
 
       - name: Update README.md benchmark report link
-        if: ${{ github.context.repo.owner == 'Cysharp' && github.ref_name == 'main' && inputs.config == 'Default' && inputs.filter == '*' }}
+        if: ${{ github.repository_owner == 'Cysharp' && github.ref_name == 'main' && inputs.config == 'Default' && inputs.filter == '*' }}
         shell: pwsh
         run: |
           $PSNativeCommandUseErrorActionPreference = $true

--- a/.github/workflows/benchmark_on_release.yaml
+++ b/.github/workflows/benchmark_on_release.yaml
@@ -30,7 +30,6 @@ jobs:
               ...baseOptions,
               inputs: {
                 config: 'Default',
-                framework: 'net10.0'
               }
             })
 
@@ -39,7 +38,6 @@ jobs:
               ...baseOptions,
               inputs: {
                 config: 'NuGetVersions',
-                framework: 'net10.0'
               }
             })
 
@@ -48,7 +46,6 @@ jobs:
               ...baseOptions,
               inputs: {
                 config: 'SystemLinq',
-                framework: 'net10.0'
               }
             })
 
@@ -56,7 +53,7 @@ jobs:
             await github.rest.actions.createWorkflowDispatch({
               ...baseOptions,
               inputs: {
-                config: 'TargetFrameworks'
+                config: 'TargetFrameworks',
               }
             })
           }

--- a/sandbox/Benchmark/Benchmarks/ShuffleBench.cs
+++ b/sandbox/Benchmark/Benchmarks/ShuffleBench.cs
@@ -5,8 +5,6 @@ using ZLinq;
 
 namespace Benchmark;
 
-#if NET10_0_OR_GREATER
-
 [GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
 public class ShuffleBench
 {
@@ -24,8 +22,10 @@ public class ShuffleBench
         array = Enumerable.Range(0, N).ToArray();
     }
 
+#if NET10_0_OR_GREATER
     [Benchmark]
     [BenchmarkCategory(Categories.LINQ)]
+    [BenchmarkCategory(Categories.Filters.NET10_0_OR_GREATER)]
     public int ShuffleTakeLinq()
     {
         var src = array.Shuffle().Take(M);
@@ -38,6 +38,7 @@ public class ShuffleBench
         }
         return i;
     }
+#endif
 
     [Benchmark]
     [BenchmarkCategory(Categories.ZLinq)]
@@ -54,5 +55,3 @@ public class ShuffleBench
     }
 
 }
-
-#endif


### PR DESCRIPTION
This PR contains following changes.
1. Fix `README.md` is not updated as expected when running `Default` benchmark.
2. Fix `ShuffleBench` build failed issue when using `TargetFrameworks` config with .NET 10 SDK.
3. Modify `benchmark_on_release.yaml`. To run all benchmarks with .NET 9.
