### PR TITLE
chore: Fix build error when using .NET 10 SDK preview.6

### DIFF
--- a/src/ZLinq/Linq/AggregateBy.cs
+++ b/src/ZLinq/Linq/AggregateBy.cs
@@ -70,7 +70,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<KeyValuePair<TKey, TAccumulate>> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<KeyValuePair<TKey, TAccumulate>> destination, Index offset) => false;
 
         public bool TryGetNext(out KeyValuePair<TKey, TAccumulate> current)
         {
@@ -164,7 +164,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<KeyValuePair<TKey, TAccumulate>> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<KeyValuePair<TKey, TAccumulate>> destination, Index offset) => false;
 
         public bool TryGetNext(out KeyValuePair<TKey, TAccumulate> current)
         {

--- a/src/ZLinq/Linq/Append.cs
+++ b/src/ZLinq/Linq/Append.cs
@@ -47,7 +47,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (destination.Length == 0) return false;
             if (!source.TryGetNonEnumeratedCount(out var srcCount)) return false;

--- a/src/ZLinq/Linq/AsValueEnumerable.cs
+++ b/src/ZLinq/Linq/AsValueEnumerable.cs
@@ -566,7 +566,7 @@ namespace ZLinq.Linq
             return true;
         }
 
-        public bool TryCopyTo(Span<T> destination, Index offset)
+        public bool TryCopyTo(scoped Span<T> destination, Index offset)
         {
 #if NET9_0_OR_GREATER
             var span = source;
@@ -794,7 +794,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<T> destination, Index offset)
+        public bool TryCopyTo(scoped Span<T> destination, Index offset)
         {
             if (source.IsSingleSegment)
             {
@@ -1206,7 +1206,7 @@ namespace ZLinq.Linq
             return true;
         }
 
-        public bool TryCopyTo(Span<T> destination, Index offset)
+        public bool TryCopyTo(scoped Span<T> destination, Index offset)
         {
             if (EnumeratorHelper.TryGetSlice<T>(source, offset, destination.Length, out var slice))
             {

--- a/src/ZLinq/Linq/Cast.cs
+++ b/src/ZLinq/Linq/Cast.cs
@@ -44,7 +44,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {

--- a/src/ZLinq/Linq/Chunk.cs
+++ b/src/ZLinq/Linq/Chunk.cs
@@ -64,7 +64,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource[]> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource[]> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource[] current)
         {

--- a/src/ZLinq/Linq/Concat.cs
+++ b/src/ZLinq/Linq/Concat.cs
@@ -69,7 +69,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             // return false because source1 succeeded but source2 failed, it is high-cost operation
             // Also, if source1 succeeds and source2 fails, there is a possibility that source1's TryCopyTo completes and TryGetNext stops working.

--- a/src/ZLinq/Linq/CountBy.cs
+++ b/src/ZLinq/Linq/CountBy.cs
@@ -57,7 +57,7 @@ namespace ZLinq.Linq
         }
 
 
-        public bool TryCopyTo(Span<KeyValuePair<TKey, int>> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<KeyValuePair<TKey, int>> destination, Index offset) => false;
 
         public bool TryGetNext(out KeyValuePair<TKey, int> current)
         {

--- a/src/ZLinq/Linq/DefaultIfEmpty.cs
+++ b/src/ZLinq/Linq/DefaultIfEmpty.cs
@@ -66,7 +66,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (destination.Length == 0) return true;
 

--- a/src/ZLinq/Linq/Distinct.cs
+++ b/src/ZLinq/Linq/Distinct.cs
@@ -50,7 +50,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (destination.Length == 1 && offset.Value == 0) // as TryGetFirst
             {

--- a/src/ZLinq/Linq/DistinctBy.cs
+++ b/src/ZLinq/Linq/DistinctBy.cs
@@ -49,7 +49,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {

--- a/src/ZLinq/Linq/Except.cs
+++ b/src/ZLinq/Linq/Except.cs
@@ -77,7 +77,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {

--- a/src/ZLinq/Linq/ExceptBy.cs
+++ b/src/ZLinq/Linq/ExceptBy.cs
@@ -76,7 +76,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {

--- a/src/ZLinq/Linq/GroupBy.cs
+++ b/src/ZLinq/Linq/GroupBy.cs
@@ -94,7 +94,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<IGrouping<TKey, TSource>> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<IGrouping<TKey, TSource>> destination, Index offset) => false;
 
         public bool TryGetNext(out IGrouping<TKey, TSource> current)
         {
@@ -186,7 +186,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<IGrouping<TKey, TElement>> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<IGrouping<TKey, TElement>> destination, Index offset) => false;
 
         public bool TryGetNext(out IGrouping<TKey, TElement> current)
         {
@@ -278,7 +278,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -370,7 +370,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {

--- a/src/ZLinq/Linq/GroupJoin.cs
+++ b/src/ZLinq/Linq/GroupJoin.cs
@@ -79,7 +79,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {

--- a/src/ZLinq/Linq/Index.cs
+++ b/src/ZLinq/Linq/Index.cs
@@ -42,7 +42,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<(int Index, TSource Item)> destination, Index offset)
+        public bool TryCopyTo(scoped Span<(int Index, TSource Item)> destination, Index offset)
         {
             // Iterate inlining
             if (source.TryGetSpan(out var span))

--- a/src/ZLinq/Linq/Intersect.cs
+++ b/src/ZLinq/Linq/Intersect.cs
@@ -78,7 +78,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {

--- a/src/ZLinq/Linq/IntersectBy.cs
+++ b/src/ZLinq/Linq/IntersectBy.cs
@@ -76,7 +76,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {

--- a/src/ZLinq/Linq/Join.cs
+++ b/src/ZLinq/Linq/Join.cs
@@ -82,7 +82,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {

--- a/src/ZLinq/Linq/LeftJoin.cs
+++ b/src/ZLinq/Linq/LeftJoin.cs
@@ -85,7 +85,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {

--- a/src/ZLinq/Linq/OfType.cs
+++ b/src/ZLinq/Linq/OfType.cs
@@ -45,7 +45,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {

--- a/src/ZLinq/Linq/OrderBy.cs
+++ b/src/ZLinq/Linq/OrderBy.cs
@@ -172,7 +172,7 @@ namespace ZLinq.Linq
             return true;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             // in-place sort needs full src buffer(no offset)
             if (source.TryGetNonEnumeratedCount(out var count) && offset.GetOffset(count) == 0)
@@ -283,7 +283,7 @@ namespace ZLinq.Linq
             }
         }
 
-        void Sort(Span<TSource> span)
+        void Sort(scoped Span<TSource> span)
         {
             if (IsAllowDirectSort())
             {
@@ -392,7 +392,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             InitBuffer();
             if (indexMap != null)

--- a/src/ZLinq/Linq/Prepend.cs
+++ b/src/ZLinq/Linq/Prepend.cs
@@ -48,7 +48,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (destination.Length == 0) return false;
             if (!source.TryGetNonEnumeratedCount(out var srcCount)) return false;

--- a/src/ZLinq/Linq/Reverse.cs
+++ b/src/ZLinq/Linq/Reverse.cs
@@ -43,7 +43,7 @@ namespace ZLinq.Linq
             return true;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             // in-place reverse needs full src buffer(no offset)
             if (source.TryGetNonEnumeratedCount(out var count) && offset.GetOffset(count) == 0)

--- a/src/ZLinq/Linq/RightJoin.cs
+++ b/src/ZLinq/Linq/RightJoin.cs
@@ -81,7 +81,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {

--- a/src/ZLinq/Linq/Select.cs
+++ b/src/ZLinq/Linq/Select.cs
@@ -66,7 +66,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset)
         {
             // Iterate inlining
             if (source.TryGetSpan(out var span))
@@ -163,7 +163,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -213,7 +213,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset)
         {
             if (EnumeratorHelper.TryGetSliceRange(count, offset, destination.Length, out var fillStart, out var fillCount))
             {
@@ -275,7 +275,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -324,7 +324,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset)
         {
             // AsSpan is failed by array variance
             if (!typeof(TSource).IsValueType && source.GetType() != typeof(TSource[]))
@@ -392,7 +392,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset)
         {
             return false;
         }
@@ -442,7 +442,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset)
         {
             if (EnumeratorHelper.TryGetSlice<TSource>(CollectionsMarshal.AsSpan(source), offset, destination.Length, out var slice))
             {
@@ -504,7 +504,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset)
         {
             return false;
         }

--- a/src/ZLinq/Linq/SelectMany.cs
+++ b/src/ZLinq/Linq/SelectMany.cs
@@ -110,7 +110,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -182,7 +182,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -254,7 +254,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -329,7 +329,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -404,7 +404,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -472,7 +472,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -540,7 +540,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -611,7 +611,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {

--- a/src/ZLinq/Linq/Shuffle.SkipTake.cs
+++ b/src/ZLinq/Linq/Shuffle.SkipTake.cs
@@ -89,7 +89,7 @@ namespace ZLinq.Linq
             return true;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             InitBuffer();
 

--- a/src/ZLinq/Linq/Shuffle.cs
+++ b/src/ZLinq/Linq/Shuffle.cs
@@ -42,7 +42,7 @@ namespace ZLinq.Linq
             return true;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             // in-place shuffle needs full src buffer(no offset)
             if (source.TryGetNonEnumeratedCount(out var count) && offset.GetOffset(count) == 0)

--- a/src/ZLinq/Linq/Skip.cs
+++ b/src/ZLinq/Linq/Skip.cs
@@ -43,7 +43,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (source.TryGetNonEnumeratedCount(out var count))
             {

--- a/src/ZLinq/Linq/SkipLast.cs
+++ b/src/ZLinq/Linq/SkipLast.cs
@@ -60,7 +60,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (source.TryGetNonEnumeratedCount(out var count))
             {

--- a/src/ZLinq/Linq/SkipWhile.cs
+++ b/src/ZLinq/Linq/SkipWhile.cs
@@ -50,7 +50,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {
@@ -111,7 +111,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {

--- a/src/ZLinq/Linq/Take.cs
+++ b/src/ZLinq/Linq/Take.cs
@@ -80,7 +80,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (source.TryGetNonEnumeratedCount(out var count))
             {
@@ -341,7 +341,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             Init();
 
@@ -507,7 +507,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (source.TryGetNonEnumeratedCount(out var sourceCount))
             {

--- a/src/ZLinq/Linq/TakeLast.cs
+++ b/src/ZLinq/Linq/TakeLast.cs
@@ -58,7 +58,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (source.TryGetNonEnumeratedCount(out var count))
             {

--- a/src/ZLinq/Linq/TakeWhile.cs
+++ b/src/ZLinq/Linq/TakeWhile.cs
@@ -49,7 +49,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {
@@ -97,7 +97,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {

--- a/src/ZLinq/Linq/Union.cs
+++ b/src/ZLinq/Linq/Union.cs
@@ -78,7 +78,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset)
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset)
         {
             if (destination.Length == 1 && offset.Value == 0) // as TryGetFirst
             {

--- a/src/ZLinq/Linq/UnionBy.cs
+++ b/src/ZLinq/Linq/UnionBy.cs
@@ -83,7 +83,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {

--- a/src/ZLinq/Linq/Where.cs
+++ b/src/ZLinq/Linq/Where.cs
@@ -75,7 +75,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {
@@ -131,7 +131,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {
@@ -185,7 +185,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -285,7 +285,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {
@@ -387,7 +387,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {

--- a/src/ZLinq/Linq/Zip.cs
+++ b/src/ZLinq/Linq/Zip.cs
@@ -103,7 +103,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<(TFirst First, TSecond Second)> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<(TFirst First, TSecond Second)> destination, Index offset) => false;
 
         public bool TryGetNext(out (TFirst First, TSecond Second) current)
         {
@@ -166,7 +166,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<(TFirst First, TSecond Second, TThird Third)> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<(TFirst First, TSecond Second, TThird Third)> destination, Index offset) => false;
 
         public bool TryGetNext(out (TFirst First, TSecond Second, TThird Third) current)
         {
@@ -225,7 +225,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TResult> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TResult> destination, Index offset) => false;
 
         public bool TryGetNext(out TResult current)
         {


### PR DESCRIPTION
This PR intended to fix build error when using .NET 10 SDK preview.6.

**Background**
When build ZLinq project with .NET 10 SDK preview.6
Following error is occurred.

> CS8987: The 'scoped' modifier of parameter 'destination' doesn't match overridden or implemented member.

It seems caused by additional validation logics that relating `scoped` modifier.
So I've added `scoped` modifier to following methods explicitly.

1. Methods that implements [ValueEnumerable::TryCopyTo](https://github.com/Cysharp/ZLinq/blob/465625f54646212569c0dc81dd3cc00f1846d0a5/src/ZLinq/ValueEnumerable.cs#L59)
2. `OrderBy::Sort` method.
