### PR TITLE
chore: Fix ZLinqBenchmarkFilter exclude condition

### DIFF
--- a/sandbox/Benchmark/BenchmarkDotNet/Filters/ZLinqBenchmarkFilter.cs
+++ b/sandbox/Benchmark/BenchmarkDotNet/Filters/ZLinqBenchmarkFilter.cs
@@ -10,19 +10,11 @@ namespace Benchmark;
 /// </summary>
 public partial class ZLinqBenchmarkFilter : IFilter
 {
-    [GeneratedRegex(@"Benchmark.ZLinq.*", RegexOptions.CultureInvariant)]
-    public static partial Regex ZLinqNamespaceRegex();
-
     public virtual bool Predicate(BenchmarkCase benchmarkCase)
     {
         // Filter by namespace
-        var fullBenchmarkName = FullNameProvider.GetBenchmarkName(benchmarkCase);
-        var nameWithoutArgs = benchmarkCase.Descriptor.GetFilterName();
-
-        bool isMatched = ZLinqNamespaceRegex().IsMatch(fullBenchmarkName)
-                      || ZLinqNamespaceRegex().IsMatch(nameWithoutArgs);
-
-        if (!isMatched)
+        var ns = benchmarkCase.Descriptor.Type.Namespace!;
+        if (!ns.StartsWith("Benchmark.ZLinq"))
             return false;
 
         switch (benchmarkCase.Job.Id)

--- a/sandbox/Benchmark/Benchmarks/DistinctBattle.cs
+++ b/sandbox/Benchmark/Benchmarks/DistinctBattle.cs
@@ -93,7 +93,7 @@ namespace ZLinq.Linq
             return false;
         }
 
-        public bool TryCopyTo(Span<TSource> destination, Index offset) => false;
+        public bool TryCopyTo(scoped Span<TSource> destination, Index offset) => false;
 
         public bool TryGetNext(out TSource current)
         {


### PR DESCRIPTION
This PR fix extra benchmark reports are included when using `ZLinqBenchmarkFilter`.

When running benchmarks with `ZLinqBenchmarkFilter`.
It's expected benchmarks that namespace starts with `Benchmark.ZLinq` are executed.
But current implementation include additional benchmarks.

**Example of benchmark report**
https://github.com/Cysharp/ZLinq/actions/runs/16308471300

Following benchmarks should not be reported for SystemLinq benchmarks.
- Benchmark.IterateBenchmark
- Benchmark.ReadMeBenchmark

**Additional changes**
Add `scoped` modifier to `DistinctBattle.cs` also  
(It's fixed by #203. But benchmark project is not tested. Because I've tested with  `System.Linq.Tests.slnx`)