### PR TITLE
chore: update System.Linq compatibility tests

### DIFF
--- a/tests/System.Linq.Tests/Stubs/xUnit/Assert.Equals.cs
+++ b/tests/System.Linq.Tests/Stubs/xUnit/Assert.Equals.cs
@@ -1,7 +1,5 @@
-using System.Linq;
-using ZLinq;
+using System.Numerics;
 using ZLinq.Linq;
-
 
 namespace ZLinq.Tests;
 
@@ -366,6 +364,21 @@ public static partial class Assert
     internal static void Equal<T>(
         ValueEnumerable<GroupBy<FromArray<T>, T, string>, IGrouping<string, T>> expected,
         IGrouping<string, T>[] actual)
+    {
+        Xunit.Assert.Equal(expected.ToArray(), actual.ToArray());
+    }
+
+    internal static void Equal<T>(
+        IEnumerable<T> expected,
+        ValueEnumerable<Take<FromInfiniteSequence<T>, T>, T> actual)
+            where T : IAdditionOperators<T, T, T>
+    {
+        Xunit.Assert.Equal(expected, actual.ToArray());
+    }
+
+    internal static void Equal(
+        ValueEnumerable<FromRange, int> expected,
+        ValueEnumerable<Take<FromRange, int>, int> actual)
     {
         Xunit.Assert.Equal(expected.ToArray(), actual.ToArray());
     }

--- a/tests/System.Linq.Tests/Stubs/xUnit/Assert.NotEmpty.cs
+++ b/tests/System.Linq.Tests/Stubs/xUnit/Assert.NotEmpty.cs
@@ -1,0 +1,14 @@
+using System.Numerics;
+using ZLinq.Linq;
+
+namespace ZLinq.Tests;
+
+public static partial class Assert
+{
+    internal static void NotEmpty<T>(
+        ValueEnumerable<FromSequence<T>, T> valueEnumerable)
+        where T : INumber<T>
+    {
+        Xunit.Assert.NotEmpty(valueEnumerable.ToArray());
+    }
+}

--- a/tests/System.Linq.Tests/Stubs/xUnit/Assert.NotSame.cs
+++ b/tests/System.Linq.Tests/Stubs/xUnit/Assert.NotSame.cs
@@ -1,11 +1,10 @@
-using System.Runtime.CompilerServices;
-using ZLinq;
+using System.Numerics;
 using ZLinq.Linq;
 
 namespace ZLinq.Tests;
 
 /// <summary>
-/// Assert.Same/NotSame rerating test is not supported.
+/// Assert.Same/NotSame relating test is not supported.
 /// </summary>
 public static partial class Assert
 {
@@ -14,7 +13,7 @@ public static partial class Assert
         ValueEnumerable<TEnumerator, T> actual)
         where TEnumerator : struct, IValueEnumerator<T>
     {
-        throw new NotSupportedException();
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
     }
 
     internal static void NotSame<TEnumerator, T>(
@@ -22,14 +21,14 @@ public static partial class Assert
         ValueEnumerable<TEnumerator, T> actual)
         where TEnumerator : struct, IValueEnumerator<T>
     {
-        throw new NotSupportedException();
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
     }
 
     internal static void NotSame<T>(
         ValueEnumerable<Select<FromEnumerable<T>, T, T>, T> expected,
         ValueEnumerable<OfType<Select<FromEnumerable<T>, T, T>, T, T>, T> actual)
     {
-        throw new NotSupportedException();
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
     }
 
     internal static void NotSame<TEnumerator, TRange, TSelect, TOfType>(
@@ -37,6 +36,42 @@ public static partial class Assert
         ValueEnumerable<OfType<Select<TEnumerator, TRange, TSelect>, TSelect, TOfType>, TOfType> actual)
             where TEnumerator : struct, IValueEnumerator<TRange>
     {
-        throw new NotSupportedException();
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
+    }
+
+    internal static void NotSame(
+        ValueEnumerable<FromRange, int> expected,
+        ValueEnumerator<FromRange, int> actual)
+    {
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
+    }
+
+    internal static void NotSame(
+        ValueEnumerator<FromRange, int> expected,
+        ValueEnumerator<FromRange, int> actual)
+    {
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
+    }
+
+    internal static void NotSame(
+        ValueEnumerator<FromInt32Sequence, int> expected,
+        ValueEnumerator<FromInt32Sequence, int> actual)
+    {
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
+    }
+
+    internal static void NotSame(
+       ValueEnumerator<FromInt32InfiniteSequence, int> expected,
+       ValueEnumerator<FromInt32InfiniteSequence, int> actual)
+    {
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
+    }
+
+    internal static void NotSame<T>(
+       ValueEnumerator<FromInfiniteSequence<T>, T> expected,
+       ValueEnumerator<FromInfiniteSequence<T>, T> actual)
+           where T : IAdditionOperators<T, T, T>
+    {
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
     }
 }

--- a/tests/System.Linq.Tests/Stubs/xUnit/Assert.Same.cs
+++ b/tests/System.Linq.Tests/Stubs/xUnit/Assert.Same.cs
@@ -14,13 +14,20 @@ public static partial class Assert
         IEnumerable<T> expected,
         ValueEnumerable<Cast<FromEnumerable<object>, object, string>, string> actual)
     {
-        throw new NotSupportedException("ZLinq use struct-based enumerator.");
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
     }
 
     internal static void Same<T>(
         IEnumerable<T> expected,
         ValueEnumerable<OfType<FromEnumerable<object>, object, T>, T> actual)
     {
-        throw new NotSupportedException("ZLinq use struct-based enumerator.");
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
+    }
+
+    internal static void Same(
+        ValueEnumerable<FromRange, int> expected,
+        ValueEnumerator<FromRange, int> actual)
+    {
+        throw new NotSupportedException("ZLinq use struct-based enumerable. Don't compare instances by reference.");
     }
 }

--- a/tests/System.Linq.Tests/Stubs/xUnit/Assert.XUnit.cs
+++ b/tests/System.Linq.Tests/Stubs/xUnit/Assert.XUnit.cs
@@ -1,10 +1,4 @@
-using System.Collections;
-using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
-using System.Linq;
-using System.Reflection;
 using System.Runtime.CompilerServices;
-using ZLinq;
 using ZLinq.Linq;
 
 namespace ZLinq.Tests;
@@ -25,6 +19,9 @@ public static partial class Assert
 
     public static void Equal<T>(IEnumerable<T> expected, IEnumerable<T> actual, IEqualityComparer<T> comparer)
         => Xunit.Assert.Equal(expected, actual, comparer);
+
+    public static void Equal(float expected, float actual, int precision)
+        => Xunit.Assert.Equal(expected, actual, precision);
 
     public static void NotEqual<T>(IEnumerable<T> expected, IEnumerable<T> actual)
         => Xunit.Assert.NotEqual(expected, actual);

--- a/tests/System.Linq.Tests/Tests/System.Linq/InfiniteSequenceTests.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/InfiniteSequenceTests.cs
@@ -1,0 +1,93 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using Xunit;
+
+#if NET10_0_OR_GREATER
+
+namespace System.Linq.Tests
+{
+    public class InfiniteSequenceTests : EnumerableTests
+    {
+        [Fact]
+        public void NullArguments_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("start", () => Enumerable.InfiniteSequence((ReferenceAddable)null!, new()));
+            AssertExtensions.Throws<ArgumentNullException>("step", () => Enumerable.InfiniteSequence(new(), (ReferenceAddable)null!));
+        }
+
+        [Fact]
+        public void MultipleGetEnumeratorCalls_ReturnsUniqueInstances()
+        {
+            var sequence = Enumerable.InfiniteSequence(0, 1);
+
+            var enumerator1 = sequence.GetEnumerator();
+            var enumerator2 = sequence.GetEnumerator();
+            Assert.NotSame(enumerator1, enumerator2);
+            enumerator1.Dispose();
+            enumerator2.Dispose();
+        }
+
+        [Fact]
+        public void InfiniteSequence_AllZeroes_MatchesExpectedOutput()
+        {
+            Assert.Equal(Enumerable.Repeat(0, 10), Enumerable.InfiniteSequence(0, 0).Take(10));
+            Assert.Equal(Enumerable.Repeat(0, 10).Select(i => (char)i), Enumerable.InfiniteSequence((char)0, (char)0).Take(10));
+            Assert.Equal(Enumerable.Repeat(0, 10).Select(i => (BigInteger)i), Enumerable.InfiniteSequence(BigInteger.Zero, BigInteger.Zero).Take(10));
+            Assert.Equal(Enumerable.Repeat(0, 10).Select(i => (float)i), Enumerable.InfiniteSequence((float)0, 0).Take(10));
+        }
+
+        [Fact]
+        public void InfiniteSequence_ProducesExpectedSequence()
+        {
+            Validate<sbyte>(0, 1);
+            Validate<sbyte>(sbyte.MaxValue - 3, 2);
+            Validate<sbyte>(sbyte.MinValue, sbyte.MaxValue / 2);
+
+            Validate<int>(0, 1);
+            Validate<int>(4, -3);
+            Validate<int>(int.MaxValue - 3, 2);
+            Validate<int>(int.MinValue, int.MaxValue / 2);
+
+            Validate<long>(0L, 1L);
+            Validate<long>(-4L, -3L);
+            Validate<long>(long.MaxValue - 3L, 2L);
+            Validate<long>(long.MinValue, long.MaxValue / 2L);
+
+            Validate<float>(0f, 1f);
+            Validate<float>(0f, -1f);
+            Validate<float>(float.MaxValue, 1f);
+            Validate<float>(float.MinValue, float.MaxValue / 2f);
+
+            Validate<BigInteger>(new BigInteger(long.MaxValue) * 3, (BigInteger)12345);
+            Validate<BigInteger>(new BigInteger(long.MaxValue) * 3, (BigInteger)(-12345));
+
+            void Validate<T>(T start, T step) where T : INumber<T>
+            {
+                var sequence = Enumerable.InfiniteSequence(start, step);
+
+                for (int trial = 0; trial < 2; trial++)
+                {
+                    using var e = sequence.GetEnumerator();
+
+                    T expected = start;
+                    for (int i = 0; i < 10; i++)
+                    {
+                        Assert.True(e.MoveNext());
+                        Assert.Equal(expected, e.Current);
+
+                        expected += step;
+                    }
+                }
+            }
+        }
+
+        private sealed class ReferenceAddable : IAdditionOperators<ReferenceAddable, ReferenceAddable, ReferenceAddable>
+        {
+            public static ReferenceAddable operator +(ReferenceAddable left, ReferenceAddable right) => left;
+            public static ReferenceAddable operator checked +(ReferenceAddable left, ReferenceAddable right) => left;
+        }
+    }
+}
+#endif

--- a/tests/System.Linq.Tests/Tests/System.Linq/RangeTests.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/RangeTests.cs
@@ -6,12 +6,43 @@ using Xunit;
 
 namespace System.Linq.Tests
 {
-    public class RangeTests : EnumerableTests
+    public class RangeTests : RangeTestsBase
     {
+        protected override IEnumerable<int> GetRange(int start, int count) => Enumerable.Range(start, count);
+
+        [Fact]
+        public void Range_ThrowExceptionOnNegativeCount()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(1, -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(1, int.MinValue));
+        }
+
+        [Fact]
+        public void Range_ThrowExceptionOnOverflow()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(1000, int.MaxValue));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(int.MaxValue, 1000));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(int.MaxValue - 10, 20));
+        }
+    }
+
+#if NET10_0_OR_GREATER
+    public class SequenceAsRangeTests : RangeTestsBase
+    {
+        protected override IEnumerable<int> GetRange(int start, int count) =>
+            count == 0 ? Enumerable.Range(start, count) :
+            Enumerable.Sequence(start, start + count - 1, 1);
+    }
+#endif
+
+    public abstract class RangeTestsBase : EnumerableTests
+    {
+        protected abstract IEnumerable<int> GetRange(int start, int count);
+
         [Fact]
         public void Range_ProduceCorrectSequence()
         {
-            var rangeSequence = Enumerable.Range(1, 100);
+            var rangeSequence = GetRange(1, 100);
             int expected = 0;
             foreach (var val in rangeSequence)
             {
@@ -34,7 +65,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(Range_ToArray_ProduceCorrectResult_MemberData))]
         public void Range_ToArray_ProduceCorrectResult(int length)
         {
-            var array = Enumerable.Range(1, length).ToArray();
+            var array = GetRange(1, length).ToArray();
             Assert.Equal(length, array.Length);
             for (var i = 0; i < array.Length; i++)
                 Assert.Equal(i + 1, array[i]);
@@ -43,7 +74,7 @@ namespace System.Linq.Tests
         [Fact]
         public void Range_ToList_ProduceCorrectResult()
         {
-            var list = Enumerable.Range(1, 100).ToList();
+            var list = GetRange(1, 100).ToList();
             Assert.Equal(100, list.Count);
             for (var i = 0; i < list.Count; i++)
                 Assert.Equal(i + 1, list[i]);
@@ -52,33 +83,18 @@ namespace System.Linq.Tests
         [Fact]
         public void Range_ZeroCountLeadToEmptySequence()
         {
-            var array = Enumerable.Range(1, 0).ToArray();
-            var array2 = Enumerable.Range(int.MinValue, 0).ToArray();
-            var array3 = Enumerable.Range(int.MaxValue, 0).ToArray();
+            var array = GetRange(1, 0).ToArray();
+            var array2 = GetRange(int.MinValue, 0).ToArray();
+            var array3 = GetRange(int.MaxValue, 0).ToArray();
             Assert.Empty(array);
             Assert.Empty(array2);
             Assert.Empty(array3);
         }
 
         [Fact]
-        public void Range_ThrowExceptionOnNegativeCount()
-        {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(1, -1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(1, int.MinValue));
-        }
-
-        [Fact]
-        public void Range_ThrowExceptionOnOverflow()
-        {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(1000, int.MaxValue));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(int.MaxValue, 1000));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(int.MaxValue - 10, 20));
-        }
-
-        [Fact]
         public void Range_NotEnumerateAfterEnd()
         {
-            using var rangeEnum = Enumerable.Range(1, 1).GetEnumerator();
+            using var rangeEnum = GetRange(1, 1).GetEnumerator();
             Assert.True(rangeEnum.MoveNext());
             Assert.False(rangeEnum.MoveNext());
             Assert.False(rangeEnum.MoveNext());
@@ -87,7 +103,7 @@ namespace System.Linq.Tests
         [Fact]
         public void Range_EnumerableAndEnumeratorAreSame()
         {
-            var rangeEnumerable = Enumerable.Range(1, 1);
+            var rangeEnumerable = GetRange(1, 1);
             using var rangeEnumerator = rangeEnumerable.GetEnumerator();
             Assert.Same(rangeEnumerable, rangeEnumerator);
         }
@@ -95,7 +111,7 @@ namespace System.Linq.Tests
         [Fact]
         public void Range_GetEnumeratorReturnUniqueInstances()
         {
-            var rangeEnumerable = Enumerable.Range(1, 1);
+            var rangeEnumerable = GetRange(1, 1);
             using var enum1 = rangeEnumerable.GetEnumerator();
             using var enum2 = rangeEnumerable.GetEnumerator();
             Assert.NotSame(enum1, enum2);
@@ -106,7 +122,7 @@ namespace System.Linq.Tests
         {
             int from = int.MaxValue - 3;
             int count = 4;
-            var rangeEnumerable = Enumerable.Range(from, count);
+            var rangeEnumerable = GetRange(from, count);
 
             Assert.Equal(count, rangeEnumerable.Count());
 
@@ -117,8 +133,8 @@ namespace System.Linq.Tests
         [Fact]
         public void RepeatedCallsSameResults()
         {
-            Assert.Equal(Enumerable.Range(-1, 2), Enumerable.Range(-1, 2));
-            Assert.Equal(Enumerable.Range(0, 0), Enumerable.Range(0, 0));
+            Assert.Equal(GetRange(-1, 2), GetRange(-1, 2));
+            Assert.Equal(GetRange(0, 0), GetRange(0, 0));
         }
 
         [Fact]
@@ -128,7 +144,7 @@ namespace System.Linq.Tests
             int count = 1;
             int[] expected = [-5];
 
-            Assert.Equal(expected, Enumerable.Range(start, count));
+            Assert.Equal(expected, GetRange(start, count));
         }
 
         [Fact]
@@ -138,95 +154,95 @@ namespace System.Linq.Tests
             int count = 6;
             int[] expected = [12, 13, 14, 15, 16, 17];
 
-            Assert.Equal(expected, Enumerable.Range(start, count));
+            Assert.Equal(expected, GetRange(start, count));
         }
 
         [Fact]
         public void Take()
         {
-            Assert.Equal(Enumerable.Range(0, 10), Enumerable.Range(0, 20).Take(10));
+            Assert.Equal(GetRange(0, 10), GetRange(0, 20).Take(10));
         }
 
         [Fact]
         public void TakeExcessive()
         {
-            Assert.Equal(Enumerable.Range(0, 10), Enumerable.Range(0, 10).Take(int.MaxValue));
+            Assert.Equal(GetRange(0, 10), GetRange(0, 10).Take(int.MaxValue));
         }
 
         [Fact]
         public void Skip()
         {
-            Assert.Equal(Enumerable.Range(10, 10), Enumerable.Range(0, 20).Skip(10));
+            Assert.Equal(GetRange(10, 10), GetRange(0, 20).Skip(10));
         }
 
         [Fact]
         public void SkipExcessive()
         {
-            Assert.Empty(Enumerable.Range(10, 10).Skip(20));
+            Assert.Empty(GetRange(10, 10).Skip(20));
         }
 
         [Fact]
         public void SkipTakeCanOnlyBeOne()
         {
-            Assert.Equal([1], Enumerable.Range(1, 10).Take(1));
-            Assert.Equal([2], Enumerable.Range(1, 10).Skip(1).Take(1));
-            Assert.Equal([3], Enumerable.Range(1, 10).Take(3).Skip(2));
-            Assert.Equal([1], Enumerable.Range(1, 10).Take(3).Take(1));
+            Assert.Equal([1], GetRange(1, 10).Take(1));
+            Assert.Equal([2], GetRange(1, 10).Skip(1).Take(1));
+            Assert.Equal([3], GetRange(1, 10).Take(3).Skip(2));
+            Assert.Equal([1], GetRange(1, 10).Take(3).Take(1));
         }
 
         [Fact]
         public void ElementAt()
         {
-            Assert.Equal(4, Enumerable.Range(0, 10).ElementAt(4));
+            Assert.Equal(4, GetRange(0, 10).ElementAt(4));
         }
 
         [Fact]
         public void ElementAtExcessiveThrows()
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => Enumerable.Range(0, 10).ElementAt(100));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => GetRange(0, 10).ElementAt(100));
         }
 
         [Fact]
         public void ElementAtOrDefault()
         {
-            Assert.Equal(4, Enumerable.Range(0, 10).ElementAtOrDefault(4));
+            Assert.Equal(4, GetRange(0, 10).ElementAtOrDefault(4));
         }
 
         [Fact]
         public void ElementAtOrDefaultExcessiveIsDefault()
         {
-            Assert.Equal(0, Enumerable.Range(52, 10).ElementAtOrDefault(100));
+            Assert.Equal(0, GetRange(52, 10).ElementAtOrDefault(100));
         }
 
         [Fact]
         public void First()
         {
-            Assert.Equal(57, Enumerable.Range(57, 1000000000).First());
+            Assert.Equal(57, GetRange(57, 1000000000).First());
         }
 
         [Fact]
         public void FirstOrDefault()
         {
-            Assert.Equal(-100, Enumerable.Range(-100, int.MaxValue).FirstOrDefault());
+            Assert.Equal(-100, GetRange(-100, int.MaxValue).FirstOrDefault());
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void Last()
         {
-            Assert.Equal(1000000056, Enumerable.Range(57, 1000000000).Last());
+            Assert.Equal(1000000056, GetRange(57, 1000000000).Last());
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void LastOrDefault()
         {
-            Assert.Equal(int.MaxValue - 101, Enumerable.Range(-100, int.MaxValue).LastOrDefault());
+            Assert.Equal(int.MaxValue - 101, GetRange(-100, int.MaxValue).LastOrDefault());
         }
 
         [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void IListImplementationIsValid()
         {
-            Validate(Enumerable.Range(42, 10), [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]);
-            Validate(Enumerable.Range(42, 10).Skip(3).Take(4), [45, 46, 47, 48]);
+            Validate(GetRange(42, 10), [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]);
+            Validate(GetRange(42, 10).Skip(3).Take(4), [45, 46, 47, 48]);
 
             static void Validate(IEnumerable<int> e, int[] expected)
             {

--- a/tests/System.Linq.Tests/Tests/System.Linq/SequenceTests.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/SequenceTests.cs
@@ -1,0 +1,313 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Numerics;
+using Xunit;
+
+#if NET10_0_OR_GREATER
+
+namespace System.Linq.Tests
+{
+    public class SequenceTests : EnumerableTests
+    {
+        [Fact]
+        public void InvalidArguments_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("start", () => Enumerable.Sequence((ReferenceAddable)null!, new(1), new(2)));
+            AssertExtensions.Throws<ArgumentNullException>("endInclusive", () => Enumerable.Sequence(new(1), (ReferenceAddable)null!, new(2)));
+            AssertExtensions.Throws<ArgumentNullException>("step", () => Enumerable.Sequence(new(1), new(2), (ReferenceAddable)null!));
+
+            // TODO: Uncomment following assertions when released .NET 10 SDK preview.7
+            // AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => Enumerable.Sequence(float.NaN, 1.0f, 1.0f));
+            // AssertExtensions.Throws<ArgumentOutOfRangeException>("endInclusive", () => Enumerable.Sequence(1.0f, float.NaN, 1.0f));
+            // AssertExtensions.Throws<ArgumentOutOfRangeException>("step", () => Enumerable.Sequence(1.0f, 1.0f, float.NaN));
+        }
+
+        [Fact]
+        public void EndOutOfRange_Throws()
+        {
+            ValidateUnsigned<byte>();
+            ValidateUnsigned<ushort>();
+            ValidateUnsigned<char>();
+            ValidateUnsigned<uint>();
+            ValidateUnsigned<ulong>();
+            ValidateUnsigned<nuint>();
+            ValidateUnsigned<UInt128>();
+
+            ValidateSigned<sbyte>();
+            ValidateSigned<short>();
+            ValidateSigned<int>();
+            ValidateSigned<long>();
+            ValidateSigned<nint>();
+            ValidateSigned<Int128>();
+            ValidateSigned<BigInteger>();
+
+            ValidateSigned<Half>();
+            ValidateSigned<float>();
+            ValidateSigned<double>();
+
+            static void ValidateSigned<T>() where T : INumber<T>
+            {
+                ValidateUnsigned<T>();
+
+                for (int i = 1; i < 3; i++)
+                {
+                    Assert.NotNull(Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(122), T.CreateTruncating(-i)));
+                }
+
+                ValidateThrows(T.CreateTruncating(123), T.CreateTruncating(124), T.CreateTruncating(-2));
+            }
+
+            static void ValidateUnsigned<T>() where T : INumber<T>
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    Assert.NotNull(Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(123), T.CreateTruncating(i)));
+                }
+
+                for (int i = 1; i < 3; i++)
+                {
+                    Assert.NotNull(Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(124), T.CreateTruncating(i)));
+                }
+
+                ValidateThrows(T.CreateTruncating(123), T.CreateTruncating(122), T.CreateTruncating(2));
+            }
+
+            static void ValidateThrows<T>(T start, T endInclusive, T step) where T : INumber<T>
+            {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("endInclusive", () => Enumerable.Sequence(start, endInclusive, step));
+            }
+        }
+
+        [Fact]
+        public void MultipleGetEnumeratorCalls_ReturnsUniqueInstances()
+        {
+            IEnumerable<int> sequence = Enumerable.Sequence(0, 4, 2);
+
+            using IEnumerator<int> enumerator1 = sequence.GetEnumerator();
+            using IEnumerator<int> enumerator2 = sequence.GetEnumerator();
+            Assert.NotSame(enumerator1, enumerator2);
+        }
+
+        [Fact]
+        public void Step1_MatchesRange()
+        {
+            Validate<byte>(0, 10);
+            Validate<ushort>(0, 10);
+            Validate<char>(0, 10);
+            Validate<uint>(0, 10);
+            Validate<ulong>(0, 10);
+            Validate<nuint>(0, 10);
+            Validate<UInt128>(0, 10);
+
+            Validate<sbyte>(-10, 10);
+            Validate<short>(-10, 10);
+            Validate<int>(-10, 10);
+            Validate<long>(-10, 10);
+            Validate<nint>(-10, 10);
+            Validate<Int128>(-10, 10);
+            Validate<BigInteger>(-10, 10);
+
+            Validate<Half>(-10, 10);
+            Validate<float>(-10, 10);
+            Validate<double>(-10, 10);
+
+            void Validate<T>(int startStart, int startEnd) where T : INumber<T>
+            {
+                for (int start = startStart; start <= startEnd; start++)
+                {
+                    for (int count = 1; count <= 20; count++)
+                    {
+                        Assert.Equal(
+                            Enumerable.Range(start, count).Select(i => T.CreateTruncating(i)),
+                            Enumerable.Sequence<T>(T.CreateTruncating(start), T.CreateTruncating(start + count - 1), T.One));
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Numbers_ProduceExpectedSequence()
+        {
+            ValidateUnsigned<byte>();
+            ValidateUnsigned<ushort>();
+            ValidateUnsigned<uint>();
+            ValidateUnsigned<ulong>();
+            ValidateUnsigned<nuint>();
+            ValidateUnsigned<UInt128>();
+
+            ValidateSigned<sbyte>();
+            ValidateSigned<short>();
+            ValidateSigned<int>();
+            ValidateSigned<long>();
+            ValidateSigned<long>();
+            ValidateSigned<nint>();
+            ValidateSigned<Int128>();
+
+            ValidateSigned<Half>();
+            ValidateSigned<float>();
+            ValidateSigned<double>();
+
+            void ValidateUnsigned<T>() where T : INumber<T>, IMinMaxValue<T>
+            {
+                Assert.Equal([T.Zero], Enumerable.Sequence(T.Zero, T.Zero, T.One));
+
+                Assert.Equal([T.Zero, T.One, T.CreateTruncating(2), T.CreateTruncating(3), T.CreateTruncating(4)], Enumerable.Sequence(T.Zero, T.CreateTruncating(4), T.One));
+                Assert.Equal([T.Zero, T.CreateTruncating(2), T.CreateTruncating(4)], Enumerable.Sequence(T.Zero, T.CreateTruncating(4), T.CreateTruncating(2)));
+                Assert.Equal([T.Zero, T.CreateTruncating(3)], Enumerable.Sequence(T.Zero, T.CreateTruncating(4), T.CreateTruncating(3)));
+                Assert.Equal([T.Zero, T.CreateTruncating(4)], Enumerable.Sequence(T.Zero, T.CreateTruncating(4), T.CreateTruncating(4)));
+                Assert.Equal([T.Zero], Enumerable.Sequence(T.Zero, T.CreateTruncating(4), T.CreateTruncating(5)));
+
+                Assert.Equal([T.CreateTruncating(42), T.CreateTruncating(45), T.CreateTruncating(48)], Enumerable.Sequence(T.CreateTruncating(42), T.CreateTruncating(50), T.CreateTruncating(3)));
+                Assert.Equal([T.CreateTruncating(42), T.CreateTruncating(45), T.CreateTruncating(48), T.CreateTruncating(51)], Enumerable.Sequence(T.CreateTruncating(42), T.CreateTruncating(51), T.CreateTruncating(3)));
+                Assert.Equal([T.MaxValue], Enumerable.Sequence(T.MaxValue, T.MaxValue, T.One));
+                Assert.Equal([T.MaxValue], Enumerable.Sequence(T.MaxValue, T.MaxValue, T.MaxValue));
+            }
+
+            void ValidateSigned<T>() where T : INumber<T>, IMinMaxValue<T>
+            {
+                ValidateUnsigned<T>();
+
+                Assert.Equal([T.One, T.Zero, T.CreateTruncating(-1), T.CreateTruncating(-2), T.CreateTruncating(-3), T.CreateTruncating(-4)], Enumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-1)));
+                Assert.Equal([T.One, T.CreateTruncating(-1), T.CreateTruncating(-3)], Enumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-2)));
+                Assert.Equal([T.One, T.CreateTruncating(-2)], Enumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-3)));
+                Assert.Equal([T.One, T.CreateTruncating(-3)], Enumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-4)));
+                Assert.Equal([T.One, T.CreateTruncating(-4)], Enumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-5)));
+                Assert.Equal([T.One], Enumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-6)));
+
+                Assert.Equal([T.MinValue], Enumerable.Sequence(T.MinValue, T.MinValue, T.CreateTruncating(-11)));
+            }
+        }
+
+        [Fact]
+        public void FloatingPoints_ProduceExpectedSequence()
+        {
+            float[] results;
+
+            results = Enumerable.Sequence(0.123f, 0.456f, 0.123f).ToArray();
+            Assert.Equal(3, results.Length);
+            Assert.Equal(0.123f, results[0], 3);
+            Assert.Equal(0.246f, results[1], 3);
+            Assert.Equal(0.369f, results[2], 3);
+
+            results = Enumerable.Sequence(0.123f, -0.456f, -0.123f).ToArray();
+            Assert.Equal(5, results.Length);
+            Assert.Equal(0.123f, results[0], 3);
+            Assert.Equal(0.0f, results[1], 3);
+            Assert.Equal(-0.123f, results[2], 3);
+            Assert.Equal(-0.246f, results[3], 3);
+            Assert.Equal(-0.369f, results[4], 3);
+
+            results = Enumerable.Sequence(16_777_216f, float.MaxValue, 1.0f).ToArray();
+            Assert.Single(results);
+            Assert.Equal(16_777_216f, results[0], 3);
+
+            results = Enumerable.Sequence(-16_777_217f, float.MinValue, -1.0f).ToArray();
+            Assert.Single(results);
+            Assert.Equal(-16_777_216f, results[0], 3);
+        }
+
+        [Fact]
+        public void SmallIntegers_ProducesFullRange()
+        {
+            byte[] bytes = Enumerable.Sequence(byte.MinValue, byte.MaxValue, (byte)1).ToArray();
+            Assert.Equal(256, bytes.Length);
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                Assert.Equal((byte)i, bytes[i]);
+            }
+
+            sbyte[] sbytes = Enumerable.Sequence(sbyte.MinValue, sbyte.MaxValue, (sbyte)1).ToArray();
+            Assert.Equal(256, sbytes.Length);
+            for (int i = 0; i < sbytes.Length; i++)
+            {
+                Assert.Equal((sbyte)(i - 128), sbytes[i]);
+            }
+
+            ushort[] ushorts = Enumerable.Sequence(ushort.MinValue, ushort.MaxValue, (ushort)1).ToArray();
+            Assert.Equal(65536, ushorts.Length);
+            for (int i = 0; i < ushorts.Length; i++)
+            {
+                Assert.Equal((ushort)i, ushorts[i]);
+            }
+
+            short[] shorts = Enumerable.Sequence(short.MinValue, short.MaxValue, (short)1).ToArray();
+            Assert.Equal(65536, shorts.Length);
+            for (int i = 0; i < shorts.Length; i++)
+            {
+                Assert.Equal((short)(i - 32768), shorts[i]);
+            }
+        }
+
+        private sealed class ReferenceAddable(int value) : INumber<ReferenceAddable>
+        {
+            public static ReferenceAddable One => throw new NotImplementedException();
+            public static int Radix => throw new NotImplementedException();
+            public static ReferenceAddable Zero => throw new NotImplementedException();
+            public static ReferenceAddable AdditiveIdentity => throw new NotImplementedException();
+            public static ReferenceAddable MultiplicativeIdentity => throw new NotImplementedException();
+            public static ReferenceAddable Abs(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsCanonical(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsComplexNumber(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsEvenInteger(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsFinite(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsImaginaryNumber(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsInfinity(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsInteger(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsNaN(ReferenceAddable value) => false;
+            public static bool IsNegative(ReferenceAddable value) => false;
+            public static bool IsNegativeInfinity(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsNormal(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsOddInteger(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsPositive(ReferenceAddable value) => false;
+            public static bool IsPositiveInfinity(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsRealNumber(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsSubnormal(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsZero(ReferenceAddable value) => false;
+            public static ReferenceAddable MaxMagnitude(ReferenceAddable x, ReferenceAddable y) => throw new NotImplementedException();
+            public static ReferenceAddable MaxMagnitudeNumber(ReferenceAddable x, ReferenceAddable y) => throw new NotImplementedException();
+            public static ReferenceAddable MinMagnitude(ReferenceAddable x, ReferenceAddable y) => throw new NotImplementedException();
+            public static ReferenceAddable MinMagnitudeNumber(ReferenceAddable x, ReferenceAddable y) => throw new NotImplementedException();
+            public static ReferenceAddable Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider) => throw new NotImplementedException();
+            public static ReferenceAddable Parse(string s, NumberStyles style, IFormatProvider? provider) => throw new NotImplementedException();
+            public static ReferenceAddable Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => throw new NotImplementedException();
+            public static ReferenceAddable Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
+            public static bool TryConvertFromChecked<TOther>(TOther value, [MaybeNullWhen(false)] out ReferenceAddable result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertFromSaturating<TOther>(TOther value, [MaybeNullWhen(false)] out ReferenceAddable result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertFromTruncating<TOther>(TOther value, [MaybeNullWhen(false)] out ReferenceAddable result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertToChecked<TOther>(ReferenceAddable value, [MaybeNullWhen(false)] out TOther result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertToSaturating<TOther>(ReferenceAddable value, [MaybeNullWhen(false)] out TOther result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertToTruncating<TOther>(ReferenceAddable value, [MaybeNullWhen(false)] out TOther result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, [MaybeNullWhen(false)] out ReferenceAddable result) => throw new NotImplementedException();
+            public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, [MaybeNullWhen(false)] out ReferenceAddable result) => throw new NotImplementedException();
+            public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, [MaybeNullWhen(false)] out ReferenceAddable result) => throw new NotImplementedException();
+            public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out ReferenceAddable result) => throw new NotImplementedException();
+            public int CompareTo(object? obj) => throw new NotImplementedException();
+            public int CompareTo(ReferenceAddable? other) => throw new NotImplementedException();
+            public bool Equals(ReferenceAddable? other) => throw new NotImplementedException();
+            public string ToString(string? format, IFormatProvider? formatProvider) => value.ToString(format, formatProvider);
+            public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) => throw new NotImplementedException();
+            public static ReferenceAddable operator +(ReferenceAddable value) => throw new NotImplementedException();
+            public static ReferenceAddable operator +(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static ReferenceAddable operator -(ReferenceAddable value) => throw new NotImplementedException();
+            public static ReferenceAddable operator -(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static ReferenceAddable operator ++(ReferenceAddable value) => throw new NotImplementedException();
+            public static ReferenceAddable operator --(ReferenceAddable value) => throw new NotImplementedException();
+            public static ReferenceAddable operator *(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static ReferenceAddable operator /(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static ReferenceAddable operator %(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static bool operator ==(ReferenceAddable? left, ReferenceAddable? right) => throw new NotImplementedException();
+            public static bool operator !=(ReferenceAddable? left, ReferenceAddable? right) => throw new NotImplementedException();
+            public static bool operator <(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static bool operator >(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static bool operator <=(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static bool operator >=(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public override bool Equals(object obj) => throw new NotImplementedException();
+            public override int GetHashCode() => throw new NotImplementedException();
+        }
+    }
+}
+#endif

--- a/tests/System.Linq.Tests/Tests/ZLinq/InfiniteSequenceTests.cs
+++ b/tests/System.Linq.Tests/Tests/ZLinq/InfiniteSequenceTests.cs
@@ -1,0 +1,90 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Numerics;
+using Xunit;
+
+namespace ZLinq.Tests
+{
+    public class InfiniteSequenceTests : EnumerableTests
+    {
+        [Fact]
+        public void NullArguments_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("start", () => ValueEnumerable.InfiniteSequence((ReferenceAddable)null!, new()));
+            AssertExtensions.Throws<ArgumentNullException>("step", () => ValueEnumerable.InfiniteSequence(new(), (ReferenceAddable)null!));
+        }
+
+        [Fact(Skip = SkipReason.RefStruct)]
+        public void MultipleGetEnumeratorCalls_ReturnsUniqueInstances()
+        {
+            var sequence = ValueEnumerable.InfiniteSequence(0, 1);
+
+            var enumerator1 = sequence.GetEnumerator();
+            var enumerator2 = sequence.GetEnumerator();
+            Assert.NotSame(enumerator1, enumerator2);
+            enumerator1.Dispose();
+            enumerator2.Dispose();
+        }
+
+        [Fact]
+        public void InfiniteSequence_AllZeroes_MatchesExpectedOutput()
+        {
+            Assert.Equal(ValueEnumerable.Repeat(0, 10).ToArray(), ValueEnumerable.InfiniteSequence(0, 0).Take(10));
+            Assert.Equal(ValueEnumerable.Repeat(0, 10).Select(i => (char)i).ToArray(), ValueEnumerable.InfiniteSequence((char)0, (char)0).Take(10));
+            Assert.Equal(ValueEnumerable.Repeat(0, 10).Select(i => (BigInteger)i).ToArray(), ValueEnumerable.InfiniteSequence(BigInteger.Zero, BigInteger.Zero).Take(10));
+            Assert.Equal(ValueEnumerable.Repeat(0, 10).Select(i => (float)i).ToArray(), ValueEnumerable.InfiniteSequence((float)0, 0).Take(10));
+        }
+
+        [Fact]
+        public void InfiniteSequence_ProducesExpectedSequence()
+        {
+            Validate<sbyte>(0, 1);
+            Validate<sbyte>(sbyte.MaxValue - 3, 2);
+            Validate<sbyte>(sbyte.MinValue, sbyte.MaxValue / 2);
+
+            Validate<int>(0, 1);
+            Validate<int>(4, -3);
+            Validate<int>(int.MaxValue - 3, 2);
+            Validate<int>(int.MinValue, int.MaxValue / 2);
+
+            Validate<long>(0L, 1L);
+            Validate<long>(-4L, -3L);
+            Validate<long>(long.MaxValue - 3L, 2L);
+            Validate<long>(long.MinValue, long.MaxValue / 2L);
+
+            Validate<float>(0f, 1f);
+            Validate<float>(0f, -1f);
+            Validate<float>(float.MaxValue, 1f);
+            Validate<float>(float.MinValue, float.MaxValue / 2f);
+
+            Validate<BigInteger>(new BigInteger(long.MaxValue) * 3, (BigInteger)12345);
+            Validate<BigInteger>(new BigInteger(long.MaxValue) * 3, (BigInteger)(-12345));
+
+            void Validate<T>(T start, T step) where T : INumber<T>
+            {
+                var sequence = ValueEnumerable.InfiniteSequence(start, step);
+
+                for (int trial = 0; trial < 2; trial++)
+                {
+                    using var e = sequence.GetEnumerator();
+
+                    T expected = start;
+                    for (int i = 0; i < 10; i++)
+                    {
+                        Assert.True(e.MoveNext());
+                        Assert.Equal(expected, e.Current);
+
+                        expected += step;
+                    }
+                }
+            }
+        }
+
+        private sealed class ReferenceAddable : IAdditionOperators<ReferenceAddable, ReferenceAddable, ReferenceAddable>
+        {
+            public static ReferenceAddable operator +(ReferenceAddable left, ReferenceAddable right) => left;
+            public static ReferenceAddable operator checked +(ReferenceAddable left, ReferenceAddable right) => left;
+        }
+    }
+}

--- a/tests/System.Linq.Tests/Tests/ZLinq/RangeTests.cs
+++ b/tests/System.Linq.Tests/Tests/ZLinq/RangeTests.cs
@@ -1,17 +1,41 @@
 // Licensed to the .NET Foundation under one or more agreements.
 // The .NET Foundation licenses this file to you under the MIT license.
 
-using System.Collections.Generic;
-using Xunit;
+using ZLinq.Linq;
 
 namespace ZLinq.Tests
 {
-    public class RangeTests : EnumerableTests
+    public class RangeTests : RangeTestsBase
     {
+        protected override ValueEnumerable<FromRange, int> GetRange(int start, int count) => ValueEnumerable.Range(start, count);
+
+        [Fact]
+        public void Range_ThrowExceptionOnNegativeCount()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(1, -1));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(1, int.MinValue));
+        }
+
+        [Fact]
+        public void Range_ThrowExceptionOnOverflow()
+        {
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(1000, int.MaxValue));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(int.MaxValue, 1000));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => GetRange(int.MaxValue - 10, 20));
+        }
+    }
+
+    // SequenceAsRangeTests is remnoved.
+    // Because there is no implicit convertion from `ValueEnumerable<FromRange, int>` to `ValueEnumerable<FromInt32Sequence, int>`
+
+    public abstract class RangeTestsBase : EnumerableTests
+    {
+        protected abstract ValueEnumerable<FromRange, int> GetRange(int start, int count);
+
         [Fact]
         public void Range_ProduceCorrectSequence()
         {
-            var rangeSequence = Enumerable.Range(1, 100);
+            var rangeSequence = GetRange(1, 100);
             int expected = 0;
             foreach (var val in rangeSequence)
             {
@@ -34,7 +58,7 @@ namespace ZLinq.Tests
         [MemberData(nameof(Range_ToArray_ProduceCorrectResult_MemberData))]
         public void Range_ToArray_ProduceCorrectResult(int length)
         {
-            var array = Enumerable.Range(1, length).ToArray();
+            var array = GetRange(1, length).ToArray();
             Assert.Equal(length, array.Length);
             for (var i = 0; i < array.Length; i++)
                 Assert.Equal(i + 1, array[i]);
@@ -43,7 +67,7 @@ namespace ZLinq.Tests
         [Fact]
         public void Range_ToList_ProduceCorrectResult()
         {
-            var list = Enumerable.Range(1, 100).ToList();
+            var list = GetRange(1, 100).ToList();
             Assert.Equal(100, list.Count);
             for (var i = 0; i < list.Count; i++)
                 Assert.Equal(i + 1, list[i]);
@@ -52,50 +76,35 @@ namespace ZLinq.Tests
         [Fact]
         public void Range_ZeroCountLeadToEmptySequence()
         {
-            var array = Enumerable.Range(1, 0).ToArray();
-            var array2 = Enumerable.Range(int.MinValue, 0).ToArray();
-            var array3 = Enumerable.Range(int.MaxValue, 0).ToArray();
-            Assert.Empty(array);
-            Assert.Empty(array2);
-            Assert.Empty(array3);
-        }
-
-        [Fact]
-        public void Range_ThrowExceptionOnNegativeCount()
-        {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(1, -1));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(1, int.MinValue));
-        }
-
-        [Fact]
-        public void Range_ThrowExceptionOnOverflow()
-        {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(1000, int.MaxValue));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(int.MaxValue, 1000));
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("count", () => Enumerable.Range(int.MaxValue - 10, 20));
+            var array = GetRange(1, 0).ToArray();
+            var array2 = GetRange(int.MinValue, 0).ToArray();
+            var array3 = GetRange(int.MaxValue, 0).ToArray();
+            Assert.Equal(0, array.Length);
+            Assert.Equal(0, array2.Length);
+            Assert.Equal(0, array3.Length);
         }
 
         [Fact]
         public void Range_NotEnumerateAfterEnd()
         {
-            using var rangeEnum = Enumerable.Range(1, 1).GetEnumerator();
+            using var rangeEnum = GetRange(1, 1).GetEnumerator();
             Assert.True(rangeEnum.MoveNext());
             Assert.False(rangeEnum.MoveNext());
             Assert.False(rangeEnum.MoveNext());
         }
 
-        [Fact]
+        [Fact(Skip = SkipReason.RefStruct)]
         public void Range_EnumerableAndEnumeratorAreSame()
         {
-            var rangeEnumerable = Enumerable.Range(1, 1);
+            var rangeEnumerable = GetRange(1, 1);
             using var rangeEnumerator = rangeEnumerable.GetEnumerator();
             Assert.Same(rangeEnumerable, rangeEnumerator);
         }
 
-        [Fact]
+        [Fact(Skip = SkipReason.RefStruct)]
         public void Range_GetEnumeratorReturnUniqueInstances()
         {
-            var rangeEnumerable = Enumerable.Range(1, 1);
+            var rangeEnumerable = GetRange(1, 1);
             using var enum1 = rangeEnumerable.GetEnumerator();
             using var enum2 = rangeEnumerable.GetEnumerator();
             Assert.NotSame(enum1, enum2);
@@ -106,7 +115,7 @@ namespace ZLinq.Tests
         {
             int from = int.MaxValue - 3;
             int count = 4;
-            var rangeEnumerable = Enumerable.Range(from, count);
+            var rangeEnumerable = GetRange(from, count);
 
             Assert.Equal(count, rangeEnumerable.Count());
 
@@ -117,8 +126,8 @@ namespace ZLinq.Tests
         [Fact]
         public void RepeatedCallsSameResults()
         {
-            Assert.Equal(Enumerable.Range(-1, 2), Enumerable.Range(-1, 2));
-            Assert.Equal(Enumerable.Range(0, 0), Enumerable.Range(0, 0));
+            Assert.Equal(GetRange(-1, 2), GetRange(-1, 2));
+            Assert.Equal(GetRange(0, 0), GetRange(0, 0));
         }
 
         [Fact]
@@ -128,7 +137,7 @@ namespace ZLinq.Tests
             int count = 1;
             int[] expected = [-5];
 
-            Assert.Equal(expected, Enumerable.Range(start, count));
+            Assert.Equal(expected, GetRange(start, count));
         }
 
         [Fact]
@@ -138,149 +147,91 @@ namespace ZLinq.Tests
             int count = 6;
             int[] expected = [12, 13, 14, 15, 16, 17];
 
-            Assert.Equal(expected, Enumerable.Range(start, count));
+            Assert.Equal(expected, GetRange(start, count));
         }
 
         [Fact]
         public void Take()
         {
-            Assert.Equal(Enumerable.Range(0, 10), Enumerable.Range(0, 20).Take(10));
+            Assert.Equal(GetRange(0, 10), GetRange(0, 20).Take(10));
         }
 
         [Fact]
         public void TakeExcessive()
         {
-            Assert.Equal(Enumerable.Range(0, 10), Enumerable.Range(0, 10).Take(int.MaxValue));
+            Assert.Equal(GetRange(0, 10), GetRange(0, 10).Take(int.MaxValue));
         }
 
         [Fact]
         public void Skip()
         {
-            Assert.Equal(Enumerable.Range(10, 10), Enumerable.Range(0, 20).Skip(10));
+            Assert.Equal(GetRange(10, 10).ToArray(), GetRange(0, 20).Skip(10));
         }
 
         [Fact]
         public void SkipExcessive()
         {
-            Assert.Empty(Enumerable.Range(10, 10).Skip(20));
+            Assert.Empty(GetRange(10, 10).Skip(20));
         }
 
         [Fact]
         public void SkipTakeCanOnlyBeOne()
         {
-            Assert.Equal([1], Enumerable.Range(1, 10).Take(1));
-            Assert.Equal([2], Enumerable.Range(1, 10).Skip(1).Take(1));
-            Assert.Equal([3], Enumerable.Range(1, 10).Take(3).Skip(2));
-            Assert.Equal([1], Enumerable.Range(1, 10).Take(3).Take(1));
+            Assert.Equal([1], GetRange(1, 10).Take(1));
+            Assert.Equal([2], GetRange(1, 10).Skip(1).Take(1));
+            Assert.Equal([3], GetRange(1, 10).Take(3).Skip(2));
+            Assert.Equal([1], GetRange(1, 10).Take(3).Take(1));
         }
 
         [Fact]
         public void ElementAt()
         {
-            Assert.Equal(4, Enumerable.Range(0, 10).ElementAt(4));
+            Assert.Equal(4, GetRange(0, 10).ElementAt(4));
         }
 
         [Fact]
         public void ElementAtExcessiveThrows()
         {
-            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => Enumerable.Range(0, 10).ElementAt(100));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => GetRange(0, 10).ElementAt(100));
         }
 
         [Fact]
         public void ElementAtOrDefault()
         {
-            Assert.Equal(4, Enumerable.Range(0, 10).ElementAtOrDefault(4));
+            Assert.Equal(4, GetRange(0, 10).ElementAtOrDefault(4));
         }
 
         [Fact]
         public void ElementAtOrDefaultExcessiveIsDefault()
         {
-            Assert.Equal(0, Enumerable.Range(52, 10).ElementAtOrDefault(100));
+            Assert.Equal(0, GetRange(52, 10).ElementAtOrDefault(100));
         }
 
         [Fact]
         public void First()
         {
-            Assert.Equal(57, Enumerable.Range(57, 1000000000).First());
+            Assert.Equal(57, GetRange(57, 1000000000).First());
         }
 
         [Fact]
         public void FirstOrDefault()
         {
-            Assert.Equal(-100, Enumerable.Range(-100, int.MaxValue).FirstOrDefault());
+            Assert.Equal(-100, GetRange(-100, int.MaxValue).FirstOrDefault());
         }
 
-
-        // ZLinq don't support Last() optimization for Enumerable.Range. Use ValueEnumerable.Range instead.
-        [Fact(Skip = SkipReason.Issue0094)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void Last()
         {
-            Assert.Equal(1000000056, Enumerable.Range(57, 1000000000).Last());
+            Assert.Equal(1000000056, GetRange(57, 1000000000).Last());
         }
 
-        [Fact(Skip = SkipReason.Issue0094)]
+        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
         public void LastOrDefault()
         {
-            Assert.Equal(int.MaxValue - 101, Enumerable.Range(-100, int.MaxValue).LastOrDefault());
+            Assert.Equal(int.MaxValue - 101, GetRange(-100, int.MaxValue).LastOrDefault());
         }
 
-        // When using ValueEnumrable. ZLinq use optimized path for Last() operation.
-        [Fact]
-        public void Last_ValueEnumerableRange()
-        {
-            Assert.Equal(1000000056, ValueEnumerable.Range(57, 1000000000).Last());
-        }
-
-        [Fact]
-        public void LastOrDefault_ValueEnumerableRange()
-        {
-            Assert.Equal(int.MaxValue - 101, ValueEnumerable.Range(-100, int.MaxValue).LastOrDefault());
-        }
-
-        [Fact]
-        public void IListImplementationIsValid()
-        {
-            Validate(Enumerable.Range(42, 10), [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]);
-            Validate(Enumerable.Range(42, 10).Skip(3).Take(4).ToArray().AsEnumerable(), [45, 46, 47, 48]);
-
-            static void Validate(IEnumerable<int> e, int[] expected)
-            {
-                IList<int> list = Assert.IsAssignableFrom<IList<int>>(e);
-                IReadOnlyList<int> roList = Assert.IsAssignableFrom<IReadOnlyList<int>>(e);
-
-                Assert.Throws<NotSupportedException>(() => list.Add(42));
-                Assert.Throws<NotSupportedException>(() => list.Insert(0, 42));
-                Assert.Throws<NotSupportedException>(() => list.Clear());
-                Assert.Throws<NotSupportedException>(() => list.Remove(42));
-                Assert.Throws<NotSupportedException>(() => list.RemoveAt(0));
-                // Assert.Throws<NotSupportedException>(() => list[0] = 42); // ZLinq version using ToArray(). so index access is allowed.
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => list[-1]);
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => list[expected.Length]);
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => roList[-1]);
-                AssertExtensions.Throws<ArgumentOutOfRangeException>("index", () => roList[expected.Length]);
-
-                Assert.True(list.IsReadOnly);
-                Assert.Equal(expected.Length, list.Count);
-                Assert.Equal(expected.Length, roList.Count);
-
-                Assert.False(list.Contains(expected[0] - 1));
-                Assert.False(list.Contains(expected[^1] + 1));
-                Assert.Equal(-1, list.IndexOf(expected[0] - 1));
-                Assert.Equal(-1, list.IndexOf(expected[^1] + 1));
-                Assert.All(expected, i => Assert.True(list.Contains(i)));
-                Assert.All(expected, i => Assert.Equal(Array.IndexOf(expected, i), list.IndexOf(i)));
-                for (int i = 0; i < expected.Length; i++)
-                {
-                    Assert.Equal(expected[i], list[i]);
-                    Assert.Equal(expected[i], roList[i]);
-                }
-
-                int[] actual = new int[expected.Length + 2];
-                list.CopyTo(actual, 1);
-                Assert.Equal(0, actual[0]);
-                Assert.Equal(0, actual[^1]);
-                AssertExtensions.SequenceEqual(expected, actual.AsSpan(1, expected.Length));
-            }
-        }
+        // IListImplementationIsValid test is removed.
+        // Because cast from `ValueEnumerable<FromRange, int>` to `IList<int>`/IReadOnlyList<int> is not supported.
     }
 }

--- a/tests/System.Linq.Tests/Tests/ZLinq/SequenceTests.cs
+++ b/tests/System.Linq.Tests/Tests/ZLinq/SequenceTests.cs
@@ -1,0 +1,309 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Numerics;
+using Xunit;
+
+namespace ZLinq.Tests
+{
+    public class SequenceTests : EnumerableTests
+    {
+        [Fact]
+        public void InvalidArguments_Throws()
+        {
+            AssertExtensions.Throws<ArgumentNullException>("start", () => ValueEnumerable.Sequence((ReferenceAddable)null!, new(1), new(2)));
+            AssertExtensions.Throws<ArgumentNullException>("endInclusive", () => ValueEnumerable.Sequence(new(1), (ReferenceAddable)null!, new(2)));
+            AssertExtensions.Throws<ArgumentNullException>("step", () => ValueEnumerable.Sequence(new(1), new(2), (ReferenceAddable)null!));
+
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => ValueEnumerable.Sequence(float.NaN, 1.0f, 1.0f));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("endInclusive", () => ValueEnumerable.Sequence(1.0f, float.NaN, 1.0f));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("step", () => ValueEnumerable.Sequence(1.0f, 1.0f, float.NaN));
+        }
+
+        [Fact]
+        public void EndOutOfRange_Throws()
+        {
+            ValidateUnsigned<byte>();
+            ValidateUnsigned<ushort>();
+            ValidateUnsigned<char>();
+            ValidateUnsigned<uint>();
+            ValidateUnsigned<ulong>();
+            ValidateUnsigned<nuint>();
+            ValidateUnsigned<UInt128>();
+
+            ValidateSigned<sbyte>();
+            ValidateSigned<short>();
+            ValidateSigned<int>();
+            ValidateSigned<long>();
+            ValidateSigned<nint>();
+            ValidateSigned<Int128>();
+            ValidateSigned<BigInteger>();
+
+            ValidateSigned<Half>();
+            ValidateSigned<float>();
+            ValidateSigned<double>();
+
+            static void ValidateSigned<T>() where T : INumber<T>
+            {
+                ValidateUnsigned<T>();
+
+                for (int i = 1; i < 3; i++)
+                {
+                    Assert.NotEmpty(ValueEnumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(122), T.CreateTruncating(-i)));
+                }
+
+                ValidateThrows(T.CreateTruncating(123), T.CreateTruncating(124), T.CreateTruncating(-2));
+            }
+
+            static void ValidateUnsigned<T>() where T : INumber<T>
+            {
+                for (int i = 0; i < 3; i++)
+                {
+                    Assert.NotEmpty(ValueEnumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(123), T.CreateTruncating(i)));
+                }
+
+                for (int i = 1; i < 3; i++)
+                {
+                    Assert.NotEmpty(ValueEnumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(124), T.CreateTruncating(i)));
+                }
+
+                ValidateThrows(T.CreateTruncating(123), T.CreateTruncating(122), T.CreateTruncating(2));
+            }
+
+            static void ValidateThrows<T>(T start, T endInclusive, T step) where T : INumber<T>
+            {
+                AssertExtensions.Throws<ArgumentOutOfRangeException>("endInclusive", () => ValueEnumerable.Sequence(start, endInclusive, step));
+            }
+        }
+
+        [Fact(Skip = SkipReason.RefStruct)]
+        public void MultipleGetEnumeratorCalls_ReturnsUniqueInstances()
+        {
+            var sequence = ValueEnumerable.Sequence(0, 4, 2);
+
+            using var enumerator1 = sequence.GetEnumerator();
+            using var enumerator2 = sequence.GetEnumerator();
+            Assert.NotSame(enumerator1, enumerator2);
+        }
+
+        [Fact]
+        public void Step1_MatchesRange()
+        {
+            Validate<byte>(0, 10);
+            Validate<ushort>(0, 10);
+            Validate<char>(0, 10);
+            Validate<uint>(0, 10);
+            Validate<ulong>(0, 10);
+            Validate<nuint>(0, 10);
+            Validate<UInt128>(0, 10);
+
+            Validate<sbyte>(-10, 10);
+            Validate<short>(-10, 10);
+            Validate<int>(-10, 10);
+            Validate<long>(-10, 10);
+            Validate<nint>(-10, 10);
+            Validate<Int128>(-10, 10);
+            Validate<BigInteger>(-10, 10);
+
+            Validate<Half>(-10, 10);
+            Validate<float>(-10, 10);
+            Validate<double>(-10, 10);
+
+            void Validate<T>(int startStart, int startEnd) where T : INumber<T>
+            {
+                for (int start = startStart; start <= startEnd; start++)
+                {
+                    for (int count = 1; count <= 20; count++)
+                    {
+                        Assert.Equal(
+                            ValueEnumerable.Range(start, count).Select(i => T.CreateTruncating(i)).ToArray(),
+                            ValueEnumerable.Sequence<T>(T.CreateTruncating(start), T.CreateTruncating(start + count - 1), T.One));
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void Numbers_ProduceExpectedSequence()
+        {
+            ValidateUnsigned<byte>();
+            ValidateUnsigned<ushort>();
+            ValidateUnsigned<uint>();
+            ValidateUnsigned<ulong>();
+            ValidateUnsigned<nuint>();
+            ValidateUnsigned<UInt128>();
+
+            ValidateSigned<sbyte>();
+            ValidateSigned<short>();
+            ValidateSigned<int>();
+            ValidateSigned<long>();
+            ValidateSigned<long>();
+            ValidateSigned<nint>();
+            ValidateSigned<Int128>();
+
+            ValidateSigned<Half>();
+            ValidateSigned<float>();
+            ValidateSigned<double>();
+
+            void ValidateUnsigned<T>() where T : INumber<T>, IMinMaxValue<T>
+            {
+                Assert.Equal([T.Zero], ValueEnumerable.Sequence(T.Zero, T.Zero, T.One));
+
+                Assert.Equal([T.Zero, T.One, T.CreateTruncating(2), T.CreateTruncating(3), T.CreateTruncating(4)], ValueEnumerable.Sequence(T.Zero, T.CreateTruncating(4), T.One));
+                Assert.Equal([T.Zero, T.CreateTruncating(2), T.CreateTruncating(4)], ValueEnumerable.Sequence(T.Zero, T.CreateTruncating(4), T.CreateTruncating(2)));
+                Assert.Equal([T.Zero, T.CreateTruncating(3)], ValueEnumerable.Sequence(T.Zero, T.CreateTruncating(4), T.CreateTruncating(3)));
+                Assert.Equal([T.Zero, T.CreateTruncating(4)], ValueEnumerable.Sequence(T.Zero, T.CreateTruncating(4), T.CreateTruncating(4)));
+                Assert.Equal([T.Zero], ValueEnumerable.Sequence(T.Zero, T.CreateTruncating(4), T.CreateTruncating(5)));
+
+                Assert.Equal([T.CreateTruncating(42), T.CreateTruncating(45), T.CreateTruncating(48)], ValueEnumerable.Sequence(T.CreateTruncating(42), T.CreateTruncating(50), T.CreateTruncating(3)));
+                Assert.Equal([T.CreateTruncating(42), T.CreateTruncating(45), T.CreateTruncating(48), T.CreateTruncating(51)], ValueEnumerable.Sequence(T.CreateTruncating(42), T.CreateTruncating(51), T.CreateTruncating(3)));
+                Assert.Equal([T.MaxValue], ValueEnumerable.Sequence(T.MaxValue, T.MaxValue, T.One));
+                Assert.Equal([T.MaxValue], ValueEnumerable.Sequence(T.MaxValue, T.MaxValue, T.MaxValue));
+            }
+
+            void ValidateSigned<T>() where T : INumber<T>, IMinMaxValue<T>
+            {
+                ValidateUnsigned<T>();
+
+                Assert.Equal([T.One, T.Zero, T.CreateTruncating(-1), T.CreateTruncating(-2), T.CreateTruncating(-3), T.CreateTruncating(-4)], ValueEnumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-1)));
+                Assert.Equal([T.One, T.CreateTruncating(-1), T.CreateTruncating(-3)], ValueEnumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-2)));
+                Assert.Equal([T.One, T.CreateTruncating(-2)], ValueEnumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-3)));
+                Assert.Equal([T.One, T.CreateTruncating(-3)], ValueEnumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-4)));
+                Assert.Equal([T.One, T.CreateTruncating(-4)], ValueEnumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-5)));
+                Assert.Equal([T.One], ValueEnumerable.Sequence(T.One, T.CreateTruncating(-4), T.CreateTruncating(-6)));
+
+                Assert.Equal([T.MinValue], ValueEnumerable.Sequence(T.MinValue, T.MinValue, T.CreateTruncating(-11)));
+            }
+        }
+
+        [Fact]
+        public void FloatingPoints_ProduceExpectedSequence()
+        {
+            float[] results;
+
+            results = ValueEnumerable.Sequence(0.123f, 0.456f, 0.123f).ToArray();
+            Assert.Equal(3, results.Length);
+            Assert.Equal(0.123f, results[0], 3);
+            Assert.Equal(0.246f, results[1], 3);
+            Assert.Equal(0.369f, results[2], 3);
+
+            results = ValueEnumerable.Sequence(0.123f, -0.456f, -0.123f).ToArray();
+            Assert.Equal(5, results.Length);
+            Assert.Equal(0.123f, results[0], 3);
+            Assert.Equal(0.0f, results[1], 3);
+            Assert.Equal(-0.123f, results[2], 3);
+            Assert.Equal(-0.246f, results[3], 3);
+            Assert.Equal(-0.369f, results[4], 3);
+
+            results = ValueEnumerable.Sequence(16_777_216f, float.MaxValue, 1.0f).ToArray();
+            Assert.Equal(1, results.Length);
+            Assert.Equal(16_777_216f, results[0], 3);
+
+            results = ValueEnumerable.Sequence(-16_777_217f, float.MinValue, -1.0f).ToArray();
+            Assert.Equal(1, results.Length);
+            Assert.Equal(-16_777_216f, results[0], 3);
+        }
+
+        [Fact]
+        public void SmallIntegers_ProducesFullRange()
+        {
+            byte[] bytes = ValueEnumerable.Sequence(byte.MinValue, byte.MaxValue, (byte)1).ToArray();
+            Assert.Equal(256, bytes.Length);
+            for (int i = 0; i < bytes.Length; i++)
+            {
+                Assert.Equal((byte)i, bytes[i]);
+            }
+
+            sbyte[] sbytes = ValueEnumerable.Sequence(sbyte.MinValue, sbyte.MaxValue, (sbyte)1).ToArray();
+            Assert.Equal(256, sbytes.Length);
+            for (int i = 0; i < sbytes.Length; i++)
+            {
+                Assert.Equal((sbyte)(i - 128), sbytes[i]);
+            }
+
+            ushort[] ushorts = ValueEnumerable.Sequence(ushort.MinValue, ushort.MaxValue, (ushort)1).ToArray();
+            Assert.Equal(65536, ushorts.Length);
+            for (int i = 0; i < ushorts.Length; i++)
+            {
+                Assert.Equal((ushort)i, ushorts[i]);
+            }
+
+            short[] shorts = ValueEnumerable.Sequence(short.MinValue, short.MaxValue, (short)1).ToArray();
+            Assert.Equal(65536, shorts.Length);
+            for (int i = 0; i < shorts.Length; i++)
+            {
+                Assert.Equal((short)(i - 32768), shorts[i]);
+            }
+        }
+
+        private sealed class ReferenceAddable(int value) : INumber<ReferenceAddable>
+        {
+            public static ReferenceAddable One => throw new NotImplementedException();
+            public static int Radix => throw new NotImplementedException();
+            public static ReferenceAddable Zero => throw new NotImplementedException();
+            public static ReferenceAddable AdditiveIdentity => throw new NotImplementedException();
+            public static ReferenceAddable MultiplicativeIdentity => throw new NotImplementedException();
+            public static ReferenceAddable Abs(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsCanonical(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsComplexNumber(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsEvenInteger(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsFinite(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsImaginaryNumber(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsInfinity(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsInteger(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsNaN(ReferenceAddable value) => false;
+            public static bool IsNegative(ReferenceAddable value) => false;
+            public static bool IsNegativeInfinity(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsNormal(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsOddInteger(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsPositive(ReferenceAddable value) => false;
+            public static bool IsPositiveInfinity(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsRealNumber(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsSubnormal(ReferenceAddable value) => throw new NotImplementedException();
+            public static bool IsZero(ReferenceAddable value) => false;
+            public static ReferenceAddable MaxMagnitude(ReferenceAddable x, ReferenceAddable y) => throw new NotImplementedException();
+            public static ReferenceAddable MaxMagnitudeNumber(ReferenceAddable x, ReferenceAddable y) => throw new NotImplementedException();
+            public static ReferenceAddable MinMagnitude(ReferenceAddable x, ReferenceAddable y) => throw new NotImplementedException();
+            public static ReferenceAddable MinMagnitudeNumber(ReferenceAddable x, ReferenceAddable y) => throw new NotImplementedException();
+            public static ReferenceAddable Parse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider) => throw new NotImplementedException();
+            public static ReferenceAddable Parse(string s, NumberStyles style, IFormatProvider? provider) => throw new NotImplementedException();
+            public static ReferenceAddable Parse(ReadOnlySpan<char> s, IFormatProvider? provider) => throw new NotImplementedException();
+            public static ReferenceAddable Parse(string s, IFormatProvider? provider) => throw new NotImplementedException();
+            public static bool TryConvertFromChecked<TOther>(TOther value, [MaybeNullWhen(false)] out ReferenceAddable result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertFromSaturating<TOther>(TOther value, [MaybeNullWhen(false)] out ReferenceAddable result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertFromTruncating<TOther>(TOther value, [MaybeNullWhen(false)] out ReferenceAddable result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertToChecked<TOther>(ReferenceAddable value, [MaybeNullWhen(false)] out TOther result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertToSaturating<TOther>(ReferenceAddable value, [MaybeNullWhen(false)] out TOther result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryConvertToTruncating<TOther>(ReferenceAddable value, [MaybeNullWhen(false)] out TOther result) where TOther : INumberBase<TOther> => throw new NotImplementedException();
+            public static bool TryParse(ReadOnlySpan<char> s, NumberStyles style, IFormatProvider? provider, [MaybeNullWhen(false)] out ReferenceAddable result) => throw new NotImplementedException();
+            public static bool TryParse([NotNullWhen(true)] string? s, NumberStyles style, IFormatProvider? provider, [MaybeNullWhen(false)] out ReferenceAddable result) => throw new NotImplementedException();
+            public static bool TryParse(ReadOnlySpan<char> s, IFormatProvider? provider, [MaybeNullWhen(false)] out ReferenceAddable result) => throw new NotImplementedException();
+            public static bool TryParse([NotNullWhen(true)] string? s, IFormatProvider? provider, [MaybeNullWhen(false)] out ReferenceAddable result) => throw new NotImplementedException();
+            public int CompareTo(object? obj) => throw new NotImplementedException();
+            public int CompareTo(ReferenceAddable? other) => throw new NotImplementedException();
+            public bool Equals(ReferenceAddable? other) => throw new NotImplementedException();
+            public string ToString(string? format, IFormatProvider? formatProvider) => value.ToString(format, formatProvider);
+            public bool TryFormat(Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? provider) => throw new NotImplementedException();
+            public static ReferenceAddable operator +(ReferenceAddable value) => throw new NotImplementedException();
+            public static ReferenceAddable operator +(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static ReferenceAddable operator -(ReferenceAddable value) => throw new NotImplementedException();
+            public static ReferenceAddable operator -(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static ReferenceAddable operator ++(ReferenceAddable value) => throw new NotImplementedException();
+            public static ReferenceAddable operator --(ReferenceAddable value) => throw new NotImplementedException();
+            public static ReferenceAddable operator *(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static ReferenceAddable operator /(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static ReferenceAddable operator %(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static bool operator ==(ReferenceAddable? left, ReferenceAddable? right) => throw new NotImplementedException();
+            public static bool operator !=(ReferenceAddable? left, ReferenceAddable? right) => throw new NotImplementedException();
+            public static bool operator <(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static bool operator >(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static bool operator <=(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public static bool operator >=(ReferenceAddable left, ReferenceAddable right) => throw new NotImplementedException();
+            public override bool Equals(object obj) => throw new NotImplementedException();
+            public override int GetHashCode() => throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
This PR update `System.Linq.Tests` project based on latest code.

#### What's changed in this PR

**1. Add `SequenceTests.cs`/`InfiniteSequenceTests.cs`**

It seems there is no compatibility issue.

Some System.Linq tests assertions failed on .NET 10 `preview.6`.
So I've added following comment that need modifications.

> // TODO: Uncomment following assertions when released .NET 10 SDK preview.7

**2. Update `RangeTests.cs`**
1. Update code based on latest code.
2. Existing ZLinq tests don't tests `ValueEnumerable.Range`. So I've updated related tests.
3. Following tests are omitted on ZLinq tests. Because interface is not compatible.
  -  `SequenceAsRangeTests`
  -  `IListImplementationIsValid`

**3. Update `Assert.*` stub methods.**

