### PR TITLE
Implement TakeLast performance optimizations and benchmarks

### DIFF
--- a/sandbox/Benchmark/Benchmarks/TakeLastBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/TakeLastBenchmark.cs
@@ -1,0 +1,55 @@
+﻿using ZLinq;
+
+namespace Benchmark;
+
+[GroupBenchmarksBy(BenchmarkLogicalGroupRule.ByCategory)]
+public class TakeLastBenchmark : EnumerableBenchmarkBase<int>
+{
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    [BenchmarkCategory(Categories.From.Array)]
+    public void FromArray_Linq()
+    {
+        foreach (var _ in source.ArrayData.TakeLast(100)) ;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    [BenchmarkCategory(Categories.From.Array)]
+    public void FromArray_ZLinq()
+    {
+        foreach (var _ in source.ArrayData.AsValueEnumerable().TakeLast(100)) ;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    [BenchmarkCategory(Categories.From.List)]
+    public void FromList_Linq()
+    {
+        foreach (var _ in source.ListData.TakeLast(100)) ;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    [BenchmarkCategory(Categories.From.List)]
+    public void FromList_ZLinq()
+    {
+        foreach (var _ in source.ListData.AsValueEnumerable().TakeLast(100)) ;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.LINQ)]
+    [BenchmarkCategory(Categories.From.Enumerable)]
+    public void FromEnumerable_Linq()
+    {
+        foreach (var _ in source.EnumerableData.TakeLast(100)) ;
+    }
+
+    [Benchmark]
+    [BenchmarkCategory(Categories.ZLinq)]
+    [BenchmarkCategory(Categories.From.Enumerable)]
+    public void FromEnumerable_ZLinq()
+    {
+        foreach (var _ in source.EnumerableData.AsValueEnumerable().TakeLast(100)) ;
+    }
+}

--- a/sandbox/Benchmark/Properties/launchSettings.json
+++ b/sandbox/Benchmark/Properties/launchSettings.json
@@ -58,6 +58,8 @@
       // "commandLineArgs": "--filter Benchmark.SimdSumUnsigned.*",
       // "commandLineArgs": "--filter Benchmark.StringJoinBenchmark.*",
       // "commandLineArgs": "--filter Benchmark.VectorizableUpdate.*",
+      // "commandLineArgs": "--filter Benchmark.TakeRangeBench.*",
+      // "commandLineArgs": "--filter Benchmark.TakeLastBenchmark.*",
       "workingDirectory": "."
     },
     "Select Benchmark": {

--- a/src/ZLinq/Internal/RentedRingBuffer.cs
+++ b/src/ZLinq/Internal/RentedRingBuffer.cs
@@ -3,9 +3,9 @@
 namespace ZLinq.Internal;
 
 [StructLayout(LayoutKind.Auto)]
-internal struct ValueRingBuffer<T>(int capacity) : IDisposable
+internal class RentedRingBuffer<T>(int capacity) : IDisposable
 {
-    public T[]? Buffer = ArrayPool<T>.Shared.Rent(capacity);
+    public T[]? Buffer = ArrayPool<T>.Shared.Rent(4);
     public readonly int Capacity = capacity;
     int head = 0;
     public int Count = 0;
@@ -14,7 +14,13 @@ internal struct ValueRingBuffer<T>(int capacity) : IDisposable
     public void Enqueue(T item)
     {
         Buffer![head] = item;
-        head = (head + 1) % Capacity;
+        var newHead = (head + 1);
+        if (newHead >= Buffer.Length)
+        {
+            Expand();
+        }
+
+        head = newHead % Capacity;
         Count = Math.Min(Count + 1, Capacity);
     }
 
@@ -35,6 +41,22 @@ internal struct ValueRingBuffer<T>(int capacity) : IDisposable
         return true;
     }
 
+    [MethodImpl(MethodImplOptions.NoInlining)]
+    void Expand()
+    {
+        if (Buffer == null || Buffer.Length < Capacity)
+        {
+            var newBuffer = ArrayPool<T>.Shared.Rent(Capacity);
+            if (Buffer != null)
+            {
+                Array.Copy(Buffer, 0, newBuffer, 0, Count);
+                ArrayPool<T>.Shared.Return(Buffer);
+            }
+
+            Buffer = newBuffer;
+            head = Count; // Reset head to the end of the current items
+        }
+    }
 
     public void Dispose()
     {

--- a/src/ZLinq/Internal/ValueRingBuffer.cs
+++ b/src/ZLinq/Internal/ValueRingBuffer.cs
@@ -1,0 +1,53 @@
+﻿using System.Buffers;
+
+namespace ZLinq.Internal;
+
+[StructLayout(LayoutKind.Auto)]
+internal struct ValueRingBuffer<T>(int capacity) : IDisposable
+{
+    public T[]? Buffer = ArrayPool<T>.Shared.Rent(capacity);
+    public readonly int Capacity = capacity;
+    int head = 0;
+    public int Count = 0;
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public void Enqueue(T item)
+    {
+        Buffer![head] = item;
+        head = (head + 1) % Capacity;
+        Count = Math.Min(Count + 1, Capacity);
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public bool TryDequeue(out T item)
+    {
+        if (Count == 0)
+        {
+            item = default!;
+            return false;
+        }
+
+        var tail = (head - Count + Capacity) % Capacity;
+        ref var tailRef = ref Buffer![tail];
+        item = tailRef;
+        tailRef = default!;
+        Count--;
+        return true;
+    }
+
+
+    public void Dispose()
+    {
+        if (Buffer != null)
+        {
+            // Clear the buffer if T contains references
+            if (RuntimeHelpers.IsReferenceOrContainsReferences<T>())
+            {
+                Buffer.AsSpan(0, Capacity).Clear();
+            }
+
+            ArrayPool<T>.Shared.Return(Buffer);
+            Buffer = null;
+        }
+    }
+}

--- a/src/ZLinq/Linq/TakeLast.cs
+++ b/src/ZLinq/Linq/TakeLast.cs
@@ -30,7 +30,7 @@ namespace ZLinq.Linq
         TEnumerator source = source;
         readonly int takeCount = Math.Max(0, count);
         int state = 0; // 0: Initial, 1: Enumerating, 2: Dequeue, 3: Completed
-        ValueRingBuffer<TSource> ringBuffer;
+        RentedRingBuffer<TSource>? ringBuffer;
 
 
         public bool TryGetNonEnumeratedCount(out int count)
@@ -101,7 +101,7 @@ namespace ZLinq.Linq
                 case 1:
                     return source.TryGetNext(out current);
                 case 2:
-                    return ringBuffer.TryDequeue(out current);
+                    return ringBuffer!.TryDequeue(out current);
                 default:
                     Unsafe.SkipInit(out current);
                     return false;
@@ -134,8 +134,8 @@ namespace ZLinq.Linq
             }
             else
             {
-                ringBuffer = new(takeCount);
-                ref var buffer = ref ringBuffer;
+
+                var buffer =  ringBuffer = new(takeCount); // Use a reasonable default capacity;
 
                 while (source.TryGetNext(out var item))
                 {
@@ -156,7 +156,7 @@ namespace ZLinq.Linq
 
         public void Dispose()
         {
-            ringBuffer.Dispose();
+            ringBuffer?.Dispose();
             source.Dispose();
         }
     }

--- a/src/ZLinq/Linq/TakeLast.cs
+++ b/src/ZLinq/Linq/TakeLast.cs
@@ -8,7 +8,6 @@
             , allows ref struct
 #endif
             => new(new(source.Enumerator, count));
-
     }
 }
 
@@ -30,7 +29,9 @@ namespace ZLinq.Linq
     {
         TEnumerator source = source;
         readonly int takeCount = Math.Max(0, count);
-        RefBox<ValueQueue<TSource>>? q;
+        int state = 0; // 0: Initial, 1: Enumerating, 2: Dequeue, 3: Completed
+        ValueRingBuffer<TSource> ringBuffer;
+
 
         public bool TryGetNonEnumeratedCount(out int count)
         {
@@ -93,42 +94,69 @@ namespace ZLinq.Linq
 
         public bool TryGetNext(out TSource current)
         {
+            switch (state)
+            {
+                case 0:
+                    return TryGetNextFirstPath(out current);
+                case 1:
+                    return source.TryGetNext(out current);
+                case 2:
+                    return ringBuffer.TryDequeue(out current);
+                default:
+                    Unsafe.SkipInit(out current);
+                    return false;
+            }
+        }
+
+        [MethodImpl(MethodImplOptions.NoInlining)]
+        bool TryGetNextFirstPath(out TSource current)
+        {
+            Unsafe.SkipInit(out current);
             if (takeCount == 0)
             {
-                Unsafe.SkipInit(out current);
+                state = 3;
                 return false;
             }
 
-            if (q == null)
+            if (source.TryGetNonEnumeratedCount(out var totalCount))
             {
-                q = new(new(4));
-            }
-
-        DEQUEUE:
-            if (q.GetValueRef().Count != 0)
-            {
-                current = q.GetValueRef().Dequeue();
-                return true;
-            }
-
-            while (source.TryGetNext(out current))
-            {
-                if (q.GetValueRef().Count == takeCount)
+                var skipCount = Math.Max(0, totalCount - takeCount);
+                while (source.TryGetNext(out current))
                 {
-                    q.GetValueRef().Dequeue();
+                    if (--skipCount >= 0) continue;
+                    state = 1; // Mark as enumerating
+                    return true;
                 }
-                q.GetValueRef().Enqueue(current);
+
+                // Source exhausted
+                state = 3;
+                return false;
             }
+            else
+            {
+                ringBuffer = new(takeCount);
+                ref var buffer = ref ringBuffer;
 
-            if (q.GetValueRef().Count != 0) goto DEQUEUE;
+                while (source.TryGetNext(out var item))
+                {
+                    buffer.Enqueue(item);
+                }
 
-            Unsafe.SkipInit(out current);
-            return false;
+                state = 2; // Mark as collected
+
+                if (buffer.TryDequeue(out current))
+                {
+                    return true;
+                }
+
+                state = 3;
+                return false;
+            }
         }
 
         public void Dispose()
         {
-            q?.Dispose();
+            ringBuffer.Dispose();
             source.Dispose();
         }
     }


### PR DESCRIPTION
#204 
Simple TakeLast(100) Benchmark.
I wonder if optimization by TryGetSpan is needed.
(In fact, it might have been better if ValueEnumerable had an InnerSkip functionality)
| Method                  | N       | Mean           | Error          | StdDev       | Gen0   | Allocated |
|------------------------ |-------- |---------------:|---------------:|-------------:|-------:|----------:|
| FromArray_Linq          | 1000000 |       228.8 ns |       33.15 ns |      1.82 ns | 0.0086 |     136 B |
| FromArray_ZLinq         | 1000000 | 3,547,090.8 ns |  171,427.16 ns |  9,396.50 ns |      - |      48 B |
| FromArray_ZLinq(PR)     | 1000000 |   469,546.8 ns |  162,486.33 ns |  8,906.42 ns |      - |         - |
|                         |         |                |                |              |        |           |
| FromList_Linq           | 1000000 |       242.9 ns |       28.69 ns |      1.57 ns | 0.0086 |     136 B |
| FromList_ZLinq          | 1000000 | 3,547,946.9 ns |  122,781.05 ns |  6,730.04 ns |      - |      48 B |
| FromList_ZLinq(PR)      | 1000000 |   545,908.3 ns |    4,946.87 ns |    271.15 ns |      - |         - |
|                         |         |                |                |              |        |           |
| FromEnumerable_Linq     | 1000000 | 4,456,278.1 ns |   76,890.24 ns |  4,214.61 ns |      - |    1368 B |
| FromEnumerable_ZLinq    | 1000000 | 4,021,346.6 ns |  164,733.85 ns |  9,029.62 ns |      - |     136 B |
| FromEnumerable_ZLinq(PR)| 1000000 | 3,410,969.7 ns |1,775,177.79 ns | 97,303.49 ns |      - |     128 B |