### PR TITLE
Fix ZLinq process for `AverageBenchmark`

### DIFF
--- a/sandbox/Benchmark/Benchmarks/ZLinq/MicroBenchmarks/Sinks/AverageBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/ZLinq/MicroBenchmarks/Sinks/AverageBenchmark.cs
@@ -18,7 +18,7 @@ public class AverageBenchmark<T> : EnumerableBenchmarkBase<T>
 #if !USE_SYSTEM_LINQ
         _ = source.Default
                   .AsValueEnumerable()
-                  .Average(x => x / T.CreateChecked(source.Length));
+                  .Average();
 #else
         _ = source.Default
                   .Cast<double>() // Cast<double> is required for System.Linq. It don't have Average<T>() overload.


### PR DESCRIPTION
I fixed the ZLinq process for `AverageBenchmark`.
ZLinq process was performing an additional division operation (`x => x / T.CreateChecked(source.Length)`), so I removed it.
