### PR TITLE
chore: Update System.Linq compatibility tests

### DIFF
--- a/tests/System.Linq.Tests/SkipReason.cs
+++ b/tests/System.Linq.Tests/SkipReason.cs
@@ -5,7 +5,7 @@ public static class SkipReason
     /// <summary>
     /// Generic skip message.
     /// </summary>
-    public const string NotCompatible = "There is not compatibility with ZLinq";
+    public const string NotCompatible = "There is no compatibility with ZLinq";
 
     /// <summary>
     /// Skip tests because it require too much CPU/memories.

--- a/tests/System.Linq.Tests/Tests/System.Linq/CountTests.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/CountTests.cs
@@ -6,7 +6,7 @@ using Xunit;
 
 namespace System.Linq.Tests
 {
-    public class CountTests : EnumerableTests
+    public class CountTests(ITestOutputHelper output) : EnumerableTests
     {
         [Fact]
         public void SameResultsRepeatCallsIntQuery()
@@ -151,6 +151,7 @@ namespace System.Linq.Tests
         [MemberData(nameof(NonEnumeratedCount_UnsupportedEnumerables))]
         public void NonEnumeratedCount_UnsupportedEnumerables_ShouldReturnFalse<T>(IEnumerable<T> source)
         {
+            output.WriteLine(source.GetType().FullName);
             Assert.False(source.TryGetNonEnumeratedCount(out int actualCount));
             Assert.Equal(0, actualCount);
         }
@@ -180,15 +181,15 @@ namespace System.Linq.Tests
 
             yield return WrapArgs(100, Enumerable.Range(1, 100));
             yield return WrapArgs(80, Enumerable.Repeat(1, 80));
+            yield return WrapArgs(20, Enumerable.Range(1, 20).Reverse());
+            yield return WrapArgs(20, Enumerable.Range(1, 20).OrderBy(x => -x));
+            yield return WrapArgs(20, Enumerable.Range(1, 10).Concat(Enumerable.Range(11, 10)));
 
             if (PlatformDetection.IsLinqSpeedOptimized)
             {
                 yield return WrapArgs(50, Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(4, new int[] { 1, 2, 3, 4 }.Select(x => x + 1));
                 yield return WrapArgs(50, Enumerable.Range(1, 50).Select(x => x + 1).Select(x => x - 1));
-                yield return WrapArgs(20, Enumerable.Range(1, 20).Reverse());
-                yield return WrapArgs(20, Enumerable.Range(1, 20).OrderBy(x => -x));
-                yield return WrapArgs(20, Enumerable.Range(1, 10).Concat(Enumerable.Range(11, 10)));
             }
 
             static object[] WrapArgs<T>(int expectedCount, IEnumerable<T> source) => [expectedCount, source];
@@ -206,9 +207,6 @@ namespace System.Linq.Tests
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1));
                 yield return WrapArgs(new int[] { 1, 2, 3, 4 }.Select(x => x + 1));
                 yield return WrapArgs(Enumerable.Range(1, 50).Select(x => x + 1).Select(x => x - 1));
-                yield return WrapArgs(Enumerable.Range(1, 20).Reverse());
-                yield return WrapArgs(Enumerable.Range(1, 20).OrderBy(x => -x));
-                yield return WrapArgs(Enumerable.Range(1, 10).Concat(Enumerable.Range(11, 10)));
             }
 
             static object[] WrapArgs<T>(IEnumerable<T> source) => [source];

--- a/tests/System.Linq.Tests/Tests/System.Linq/MinTests.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/MinTests.cs
@@ -824,7 +824,7 @@ namespace System.Linq.Tests
         }
 
         [Fact]
-        public void Min_Bool_EmptySource_ThrowsInvalodOperationException()
+        public void Min_Bool_EmptySource_ThrowsInvalidOperationException()
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<bool>().Min());
             Assert.Throws<InvalidOperationException>(() => ForceNotCollection(Enumerable.Empty<bool>()).Min());

--- a/tests/System.Linq.Tests/Tests/System.Linq/OrderedSubsetting.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/OrderedSubsetting.cs
@@ -224,7 +224,7 @@ namespace System.Linq.Tests
             Assert.Equal(Enumerable.Range(10, 1), ordered.Take(11).Skip(10));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
+        [Fact]
         public void TakeAndSkip_DoesntIterateRangeUnlessNecessary()
         {
             Assert.Empty(Enumerable.Range(0, int.MaxValue).Take(int.MaxValue).OrderBy(i => i).Skip(int.MaxValue - 4).Skip(15));

--- a/tests/System.Linq.Tests/Tests/System.Linq/RangeTests.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/RangeTests.cs
@@ -238,7 +238,7 @@ namespace System.Linq.Tests
             Assert.Equal(int.MaxValue - 101, GetRange(-100, int.MaxValue).LastOrDefault());
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
+        [Fact]
         public void IListImplementationIsValid()
         {
             Validate(GetRange(42, 10), [42, 43, 44, 45, 46, 47, 48, 49, 50, 51]);

--- a/tests/System.Linq.Tests/Tests/System.Linq/SelectTests.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/SelectTests.cs
@@ -13,6 +13,32 @@ namespace System.Linq.Tests
     public class SelectTests : EnumerableTests
     {
         [Fact]
+        public void SelectSideEffectsExecutedOnCount()
+        {
+            int i = 0;
+            // If we made no promises about side effects, i could be 0, but in practice users have
+            // taken a dependency on side effects executing on Count.
+            var count = Enumerable.Range(1, 10).Select(x => i++).Count();
+            Assert.Equal(10, count);
+            Assert.Equal(10, i);
+
+            i = 0;
+            count = Enumerable.Range(1, 10).Skip(5).Select(x => i++).Count();
+            Assert.Equal(5, count);
+            Assert.Equal(5, i);
+
+            i = 0;
+            count = Enumerable.Range(1, 10).Take(5).Select(x => i++).Count();
+            Assert.Equal(5, count);
+            Assert.Equal(5, i);
+
+            i = 0;
+            count = Enumerable.Range(1, 10).Skip(2).Take(3).Select(x => i++).Count();
+            Assert.Equal(3, count);
+            Assert.Equal(3, i);
+        }
+
+        [Fact]
         public void SameResultsRepeatCallsStringQuery()
         {
             var q1 = from x1 in new string[] { "Alen", "Felix", null, null, "X", "Have Space", "Clinton", "" }

--- a/tests/System.Linq.Tests/Tests/System.Linq/SequenceTests.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/SequenceTests.cs
@@ -20,10 +20,9 @@ namespace System.Linq.Tests
             AssertExtensions.Throws<ArgumentNullException>("endInclusive", () => Enumerable.Sequence(new(1), (ReferenceAddable)null!, new(2)));
             AssertExtensions.Throws<ArgumentNullException>("step", () => Enumerable.Sequence(new(1), new(2), (ReferenceAddable)null!));
 
-            // TODO: Uncomment following assertions when released .NET 10 SDK preview.7
-            // AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => Enumerable.Sequence(float.NaN, 1.0f, 1.0f));
-            // AssertExtensions.Throws<ArgumentOutOfRangeException>("endInclusive", () => Enumerable.Sequence(1.0f, float.NaN, 1.0f));
-            // AssertExtensions.Throws<ArgumentOutOfRangeException>("step", () => Enumerable.Sequence(1.0f, 1.0f, float.NaN));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("start", () => Enumerable.Sequence(float.NaN, 1.0f, 1.0f));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("endInclusive", () => Enumerable.Sequence(1.0f, float.NaN, 1.0f));
+            AssertExtensions.Throws<ArgumentOutOfRangeException>("step", () => Enumerable.Sequence(1.0f, 1.0f, float.NaN));
         }
 
         [Fact]
@@ -53,25 +52,28 @@ namespace System.Linq.Tests
             {
                 ValidateUnsigned<T>();
 
-                for (int i = 1; i < 3; i++)
-                {
-                    Assert.NotNull(Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(122), T.CreateTruncating(-i)));
-                }
+                // Test negative steps from 123 to 122
+                // step=-1: should give [123, 122] (2 elements)
+                // step=-2: should give [123] (1 element, step too large)
+                Assert.Equal(2, Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(122), T.CreateTruncating(-1)).Count());
+                Assert.Single(Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(122), T.CreateTruncating(-2)));
 
                 ValidateThrows(T.CreateTruncating(123), T.CreateTruncating(124), T.CreateTruncating(-2));
             }
 
             static void ValidateUnsigned<T>() where T : INumber<T>
             {
+                // When start == end, all steps should return single element [123]
                 for (int i = 0; i < 3; i++)
                 {
-                    Assert.NotNull(Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(123), T.CreateTruncating(i)));
+                    Assert.Single(Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(123), T.CreateTruncating(i)));
                 }
 
-                for (int i = 1; i < 3; i++)
-                {
-                    Assert.NotNull(Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(124), T.CreateTruncating(i)));
-                }
+                // Test positive steps from 123 to 124
+                // step=1: should give [123, 124] (2 elements)
+                // step=2: should give [123] (1 element, step too large)
+                Assert.Equal(2, Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(124), T.CreateTruncating(1)).Count());
+                Assert.Single(Enumerable.Sequence(T.CreateTruncating(123), T.CreateTruncating(124), T.CreateTruncating(2)));
 
                 ValidateThrows(T.CreateTruncating(123), T.CreateTruncating(122), T.CreateTruncating(2));
             }

--- a/tests/System.Linq.Tests/Tests/System.Linq/TakeTests.cs
+++ b/tests/System.Linq.Tests/Tests/System.Linq/TakeTests.cs
@@ -669,7 +669,7 @@ namespace System.Linq.Tests
             }
         }
 
-        [ConditionalTheory(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
+        [Theory]
         [InlineData(1000)]
         [InlineData(1000000)]
         [InlineData(int.MaxValue)]
@@ -1623,7 +1623,7 @@ namespace System.Linq.Tests
             Assert.Empty(EnumerablePartitionOrEmpty(source).Take(^6..^7));
         }
 
-        [ConditionalFact(typeof(PlatformDetection), nameof(PlatformDetection.IsLinqSpeedOptimized))]
+        [Fact]
         public void SkipTakeOnIListIsIList()
         {
             IList<int> list = new ReadOnlyCollection<int>(Enumerable.Range(0, 100).ToList());

--- a/tests/System.Linq.Tests/Tests/ZLinq/MinTests.cs
+++ b/tests/System.Linq.Tests/Tests/ZLinq/MinTests.cs
@@ -871,7 +871,7 @@ namespace ZLinq.Tests
         }
 
         [Fact]
-        public void Min_Bool_EmptySource_ThrowsInvalodOperationException()
+        public void Min_Bool_EmptySource_ThrowsInvalidOperationException()
         {
             Assert.Throws<InvalidOperationException>(() => Enumerable.Empty<bool>().Min());
             Assert.Throws<InvalidOperationException>(() => ForceNotCollection(Enumerable.Empty<bool>()).Min());

--- a/tests/System.Linq.Tests/Tests/ZLinq/SelectTests.cs
+++ b/tests/System.Linq.Tests/Tests/ZLinq/SelectTests.cs
@@ -12,6 +12,32 @@ namespace ZLinq.Tests
 {
     public class SelectTests : EnumerableTests
     {
+        [Fact(Skip = SkipReason.NotCompatible)]
+        public void SelectSideEffectsExecutedOnCount()
+        {
+            int i = 0;
+            // If we made no promises about side effects, i could be 0, but in practice users have
+            // taken a dependency on side effects executing on Count.
+            var count = Enumerable.Range(1, 10).Select(x => i++).Count();
+            Assert.Equal(10, count);
+            Assert.Equal(10, i);
+
+            i = 0;
+            count = Enumerable.Range(1, 10).Skip(5).Select(x => i++).Count();
+            Assert.Equal(5, count);
+            Assert.Equal(5, i);
+
+            i = 0;
+            count = Enumerable.Range(1, 10).Take(5).Select(x => i++).Count();
+            Assert.Equal(5, count);
+            Assert.Equal(5, i);
+
+            i = 0;
+            count = Enumerable.Range(1, 10).Skip(2).Take(3).Select(x => i++).Count();
+            Assert.Equal(3, count);
+            Assert.Equal(3, i);
+        }
+
         [Fact]
         public void SameResultsRepeatCallsStringQuery()
         {


### PR DESCRIPTION
This PR update `System.Linq` compatibility tests based on latest code.
https://github.com/dotnet/runtime/commits/main/src/libraries/System.Linq/tests

### What's changed in this PR

**1. SkipReason.cs**
Fix test skip message.

**2. CountTests.cs**
Modify test code based on .NET 10 RC1

**3. MinTests.cs**
Fix typo.

**4. OrderedSubsetting.cs**
**5. RangeTests.cs**
**6. TakeTests.cs**
**7. SequenceTests.cs**
Modify test code based on .NET 10 RC1

**8. SelectTests.cs**
Add `SelectSideEffectsExecutedOnCount` test code.

This test is skipped on ZLinq.
Because ZLinq seems not allow side-effect inside LINQ query.
