### PR TITLE
chore: Update package dependencies and modify code to support .NET 10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -33,9 +33,6 @@
 
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
-    <!-- CS9074: The 'scoped' modifier of parameter 'span' doesn't match overridden or implemented member.-->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS9074</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -37,8 +37,6 @@
 
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <!-- CS9074: The 'scoped' modifier of parameter 'span' doesn't match overridden or implemented member.-->
-    <WarningsNotAsErrors>$(WarningsNotAsErrors);CS9074</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -31,8 +31,8 @@
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
-    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36127.1" />
-    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.UserMarks" Version="18.0.36127.1" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.BenchmarkDotNetDiagnosers" Version="18.0.36421.1" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.UserMarks" Version="18.0.36421.1" />
     <PackageReference Include="Kokuban" Version="0.2.0" />
   </ItemGroup>
 

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.UserMarks" Version="18.0.36127.1" />
+    <PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.UserMarks" Version="18.0.36421.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/sandbox/ConsoleAppNet6/ConsoleAppNet6.csproj
+++ b/sandbox/ConsoleAppNet6/ConsoleAppNet6.csproj
@@ -7,6 +7,7 @@
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/FileGen/FileGen.csproj
+++ b/src/FileGen/FileGen.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ConsoleAppFramework" Version="5.4.1">
+    <PackageReference Include="ConsoleAppFramework" Version="5.6.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/ZLinq.Json/ZLinq.Json.csproj
+++ b/src/ZLinq.Json/ZLinq.Json.csproj
@@ -26,7 +26,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
-    <PackageReference Include="System.Text.Json" Version="9.0.6" />
+    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/ZLinq/Linq/JoinToString.cs
+++ b/src/ZLinq/Linq/JoinToString.cs
@@ -4,7 +4,10 @@ partial class ValueEnumerableExtensions
 {
     const int StackallocCharBufferSizeLimit = 256;
 
-#if NET8_0_OR_GREATER
+#if NET10_0_OR_GREATER
+    [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "FastAllocateString")]
+    static extern string FastAllocateString(string _, nint length);
+#elif NET8_0_OR_GREATER
     [UnsafeAccessor(UnsafeAccessorKind.StaticMethod, Name = "FastAllocateString")]
     static extern string FastAllocateString(string _, int length);
 #else

--- a/src/ZLinq/ZLinq.csproj
+++ b/src/ZLinq/ZLinq.csproj
@@ -19,8 +19,8 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
-  <!-- Add .NET 10 support when running build inside Visual Studio Preview-->
-  <PropertyGroup Condition="'$(BuildingInsideVisualStudio)' != '' AND $(VisualStudioDir.Contains('Preview'))">
+  <!-- Add .NET 10 support if .NET 10 or later version of MSBuild is used. -->
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','10.0'))">
     <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
   </PropertyGroup>
 
@@ -38,7 +38,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.6" />
+    <PackageReference Include="Microsoft.Bcl.Memory" Version="9.0.9" />
     <PackageReference Include="System.Buffers" Version="4.6.1" />
     <PackageReference Include="System.Memory" Version="4.6.3" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.2" />

--- a/tests/System.Linq.Tests/Stubs/xUnit/ConditionalFactAttribute.cs
+++ b/tests/System.Linq.Tests/Stubs/xUnit/ConditionalFactAttribute.cs
@@ -1,10 +1,12 @@
+using System.Runtime.CompilerServices;
 using ZLinq.Tests;
 
 namespace Xunit;
 
 internal class ConditionalFactAttribute : FactAttribute
 {
-    public ConditionalFactAttribute(Type type, string key)
+    public ConditionalFactAttribute(Type type, string key, [CallerFilePath] string? sourceFilePath = null, [CallerLineNumber] int sourceLineNumber = -1)
+         : base(sourceFilePath, sourceLineNumber)
     {
         bool isEnabled = ConditionalUtils.IsEnable(type, key);
         if (isEnabled)

--- a/tests/System.Linq.Tests/Stubs/xUnit/ConditionalTheoryAttribute.cs
+++ b/tests/System.Linq.Tests/Stubs/xUnit/ConditionalTheoryAttribute.cs
@@ -1,10 +1,12 @@
+using System.Runtime.CompilerServices;
 using ZLinq.Tests;
 
 namespace Xunit;
 
 internal class ConditionalTheoryAttribute : TheoryAttribute
 {
-    public ConditionalTheoryAttribute(Type type, string key)
+    public ConditionalTheoryAttribute(Type type, string key, [CallerFilePath] string? sourceFilePath = null, [CallerLineNumber] int sourceLineNumber = -1)
+               : base(sourceFilePath, sourceLineNumber)
     {
         bool isEnabled = ConditionalUtils.IsEnable(type, key);
         if (isEnabled)

--- a/tests/System.Linq.Tests/System.Linq.Tests.csproj
+++ b/tests/System.Linq.Tests/System.Linq.Tests.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit.v3" Version="2.0.3" />
+    <PackageReference Include="xunit.v3" Version="3.0.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
   </ItemGroup>
 

--- a/tests/ZLinq.Tests/ZLinq.Tests.csproj
+++ b/tests/ZLinq.Tests/ZLinq.Tests.csproj
@@ -27,14 +27,18 @@
     <TargetFrameworks>net10.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
+  <!-- Disable EOL warning for net6.0 -->
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
+  </PropertyGroup>
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="xunit.v3" Version="[1.1.0]" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="xunit.v3" Version="2.0.3" />
+    <PackageReference Include="xunit.v3" Version="3.0.1" />
   </ItemGroup>
-
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net48'">
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="6.0.0" />
@@ -71,7 +75,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1"   Condition="'$(TargetFramework)' != 'net6.0'"/>
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
This PR contains following changes

**1. Update package dependencies to latest version**

**2. Remove `CS9074` warning suppressions**
It's added by #118.
But It's not happens when build project with .NET 10 RC1.

**3. Add `CheckEolTargetFramework` setting for project that using .NET 6**
It's required to suppress `NETSDK1138` warnings.

**4. Modify `FastAllocateString` method signature for .NET 10 or later.**
It's required because some tests of `JoinToStringTest` failed with following error when running on .NET 10 RC1
> System.MissingMethodException : Method not found: 'System.String.FastAllocateString'.

**5. Modify `ConditionalTheory`/`ConditionalFact` attribute constructor**
It's required to suppress [xUnit3003](https://xunit.net/xunit.analyzers/rules/xUnit3003.html) warnings.

I've confirmed method signature is changed at [String.CoreCLR.cs](https://github.com/dotnet/runtime/blob/v10.0.0-rc.1.25451.107/src/coreclr/System.Private.CoreLib/src/System/String.CoreCLR.cs#L27-L28)

Note: 
Mono/NativeAot runtimes have different method signatures.
So it might need to additional logics to support these runtimes. 

https://github.com/dotnet/runtime/blob/v10.0.0-rc.1.25451.107/src/mono/System.Private.CoreLib/src/System/String.Mono.cs#L24-L25
https://github.com/dotnet/runtime/blob/v10.0.0-rc.1.25451.107/src/coreclr/nativeaot/System.Private.CoreLib/src/System/String.NativeAot.cs#L21

**6. Modify `ZLinq.csproj` to support .NET 10**
It's same changes as #183.
It's required to support .NET 19 build with Visual Studio 2026 Insider.
