### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,8 +77,18 @@ publish
 # Publish Web Output
 *.Publish.xml
 
-# NuGet Packages Directory
-packages
+# NuGet Packages
+*.snupkg
+*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
 
 # Windows Azure Build Output
 csx

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,14 @@
 ﻿<Project>
 
   <PropertyGroup>
+    <NoWarn>1591</NoWarn>
+    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
+
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
+
     <!-- NuGet Packaging -->
+    <IsPackable>false</IsPackable>
     <PackageVersion>$(Version)</PackageVersion>
     <Company>Cysharp</Company>
     <Authors>Cysharp</Authors>
@@ -11,11 +18,8 @@
     <RepositoryType>git</RepositoryType>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageIcon>Icon.png</PackageIcon>
-    <SignAssembly>true</SignAssembly>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)opensource.snk</AssemblyOriginatorKeyFile>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <NoWarn>1591</NoWarn>
 
     <!-- NuGet deterministic build -->
     <Deterministic>true</Deterministic>
@@ -33,17 +37,13 @@
 
   <PropertyGroup Condition="'$(ContinuousIntegrationBuild)' == 'true'">
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-
     <!-- CS9074: The 'scoped' modifier of parameter 'span' doesn't match overridden or implemented member.-->
     <WarningsNotAsErrors>$(WarningsNotAsErrors);CS9074</WarningsNotAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
   </ItemGroup>
-
-  <PropertyGroup>
-    <SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
-  </PropertyGroup>
-
 </Project>

--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -7,7 +7,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <IsPackable>false</IsPackable>
 
     <!-- CS8002: Referenced assembly does not have a strong name.-->
     <NoWarn>$(NoWarn);CS8002</NoWarn>

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
 
     <DefineConstants>DIAGHUB_ENABLE_TRACE_SYSTEM</DefineConstants>

--- a/sandbox/ConsoleAppNativeAOT/ConsoleAppNativeAOT.csproj
+++ b/sandbox/ConsoleAppNativeAOT/ConsoleAppNativeAOT.csproj
@@ -8,7 +8,6 @@
     <PublishTrimmed>true</PublishTrimmed>
     <PublishSingleFile>true</PublishSingleFile>
     <SelfContained>true</SelfContained>
-    <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 

--- a/sandbox/ConsoleAppNet6/ConsoleAppNet6.csproj
+++ b/sandbox/ConsoleAppNet6/ConsoleAppNet6.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <IsPackable>false</IsPackable>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
   </PropertyGroup>
 

--- a/src/FileGen/FileGen.csproj
+++ b/src/FileGen/FileGen.csproj
@@ -6,7 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
-    <IsPackable>false</IsPackable>
+
+    <!-- This is not a nuget package -->
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ZLinq.DropInGenerator/ZLinq.DropInGenerator.csproj
+++ b/src/ZLinq.DropInGenerator/ZLinq.DropInGenerator.csproj
@@ -16,6 +16,7 @@
     <DefineConstants>SOURCE_GENERATOR</DefineConstants>
 
     <!-- NuGet Packaging -->
+    <IsPackable>true</IsPackable>
     <PackageTags>linq</PackageTags>
     <Description>DropIn replacement Source Generator for ZLinq.</Description>
   </PropertyGroup>
@@ -25,7 +26,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="../../Icon.png" Pack="true" PackagePath="/" />
     <!-- Create nuget package as analyzer -->
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>

--- a/src/ZLinq.FileSystem/ZLinq.FileSystem.csproj
+++ b/src/ZLinq.FileSystem/ZLinq.FileSystem.csproj
@@ -8,6 +8,7 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
 
     <!-- NuGet Packaging -->
+    <IsPackable>true</IsPackable>
     <PackageTags>linq</PackageTags>
     <Description>LINQ to FileSystem; FileSystem extensions of ZLinq's LINQ to Tree.</Description>
   </PropertyGroup>
@@ -18,11 +19,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    <EmbeddedResource Include="..\..\LICENSE" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ZLinq.Godot/ZLinq.Godot.csproj
+++ b/src/ZLinq.Godot/ZLinq.Godot.csproj
@@ -7,6 +7,7 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
 
     <!-- NuGet Packaging -->
+    <IsPackable>true</IsPackable>
     <PackageTags>linq</PackageTags>
     <Description>LINQ to Godot's node tree; Node extensions of ZLinq's LINQ to Tree.</Description>
   </PropertyGroup>
@@ -14,13 +15,11 @@
   <ItemGroup>
     <ProjectReference Include="..\ZLinq\ZLinq.csproj" />
   </ItemGroup>
-  <ItemGroup>
-    <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    <EmbeddedResource Include="..\..\LICENSE" />
-  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="GodotSharp" Version="4.0.0" />
   </ItemGroup>
+
   <ItemGroup>
     <Using Include="ZLinq" />
     <Using Include="ZLinq.Internal" />

--- a/src/ZLinq.Json/ZLinq.Json.csproj
+++ b/src/ZLinq.Json/ZLinq.Json.csproj
@@ -8,6 +8,7 @@
     <NoWarn>$(NoWarn);CS8002</NoWarn>
 
     <!-- NuGet Packaging -->
+    <IsPackable>true</IsPackable>
     <PackageTags>linq</PackageTags>
     <Description>LINQ to Json; JsonNode(System.Text.Json) extensions of ZLinq's LINQ to Tree.</Description>
   </PropertyGroup>
@@ -20,15 +21,10 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup>
-    <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    <EmbeddedResource Include="..\..\LICENSE" />
-  </ItemGroup>
-
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0' OR $(TargetFramework) == 'netstandard2.1'">
     <PackageReference Include="System.Text.Json" Version="9.0.6" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <Using Include="ZLinq" />
     <Using Include="ZLinq.Internal" />

--- a/src/ZLinq/ZLinq.csproj
+++ b/src/ZLinq/ZLinq.csproj
@@ -10,6 +10,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- NuGet Packaging -->
+    <IsPackable>true</IsPackable>
     <PackageTags>linq</PackageTags>
     <Description>Zero allocation LINQ with LINQ to Span, LINQ to SIMD, and LINQ to Tree (FileSystem, JSON, GameObject, etc.) for all .NET platforms and Unity.</Description>
   </PropertyGroup>
@@ -27,11 +28,6 @@
   <PropertyGroup Condition="$(TargetFramework.StartsWith(`netstandard`))">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="../../Icon.png" Pack="true" PackagePath="/" />
-    <EmbeddedResource Include="..\..\LICENSE" />
-  </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
     <PackageReference Include="PolySharp" Version="1.15.0">

--- a/tests/System.Linq.Tests/System.Linq.Tests.csproj
+++ b/tests/System.Linq.Tests/System.Linq.Tests.csproj
@@ -7,7 +7,6 @@
     <Nullable>enable</Nullable>
     <TargetFrameworks>net9.0</TargetFrameworks>
     <LangVersion>13</LangVersion>
-    <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Use custom root namespace -->

--- a/tests/ZLinq.Tests/ZLinq.Tests.csproj
+++ b/tests/ZLinq.Tests/ZLinq.Tests.csproj
@@ -6,7 +6,6 @@
     <Nullable>enable</Nullable>
     <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
     <LangVersion>13</LangVersion>
-    <IsPackable>false</IsPackable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS8002;CS0618</NoWarn>
 


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
