### PR TITLE
Optimize TryGetNext for arrays

### DIFF
--- a/src/ZLinq/Internal/SegmentedArrayProvider.cs
+++ b/src/ZLinq/Internal/SegmentedArrayProvider.cs
@@ -303,7 +303,7 @@ internal static class InlineArrayMarshal
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static ref TElement ElementRef<TBuffer, TElement>(ref TBuffer buffer, int index)
     {
-        return ref Unsafe.Add(ref Unsafe.As<TBuffer, TElement>(ref buffer), index);
+        return ref Unsafe.Add(ref Unsafe.As<TBuffer, TElement>(ref buffer), (nint)(uint)index);
     }
 }
 

--- a/src/ZLinq/Linq/AsValueEnumerable.cs
+++ b/src/ZLinq/Linq/AsValueEnumerable.cs
@@ -536,7 +536,7 @@ namespace ZLinq.Linq
 
             if ((uint)index < (uint)length)
             {
-                current = Unsafe.Add(ref firstElement, index);
+                current = Unsafe.Add(ref firstElement, (nint)(uint)index);
                 index++;
                 return true;
             }

--- a/src/ZLinq/Linq/Select.cs
+++ b/src/ZLinq/Linq/Select.cs
@@ -352,7 +352,7 @@ namespace ZLinq.Linq
 
             if ((uint)index < (uint)length)
             {
-                current = selector(Unsafe.Add(ref firstElement, index++)); // must be index++
+                current = selector(Unsafe.Add(ref firstElement, (nint)(uint)index++)); // must be index++
                 return true;
             }
 #else
@@ -416,7 +416,7 @@ namespace ZLinq.Linq
 
             while ((uint)index < (uint)length)
             {
-                current = selector(Unsafe.Add(ref firstElement, index++));
+                current = selector(Unsafe.Add(ref firstElement, (nint)(uint)index++));
                 if (predicate(current))
                 {
                     return true;

--- a/src/ZLinq/Linq/Where.cs
+++ b/src/ZLinq/Linq/Where.cs
@@ -239,7 +239,7 @@ namespace ZLinq.Linq
 
             while ((uint)index < (uint)length)
             {
-                var value = Unsafe.Add(ref firstElement, index);
+                var value = Unsafe.Add(ref firstElement, (nint)(uint)index);
                 index++;
                 if (predicate(value))
                 {
@@ -311,7 +311,7 @@ namespace ZLinq.Linq
 
             while ((uint)index < (uint)length)
             {
-                var value = Unsafe.Add(ref firstElement, index);
+                var value = Unsafe.Add(ref firstElement, (nint)(uint)index);
                 index++;
                 if (predicate(value))
                 {


### PR DESCRIPTION
## Background

I was looking into the original LINQ implementation and noticed that we are not trying to [hoist variables](https://source.dot.net/#System.Linq/System/Linq/Where.cs,285). We can't hoist the index because the library is employing a different pattern (and there is no Current state). However, we can hoist length/array.

Secondly, I've been looking to eliminate bounds checks, and `((uint)index < (uint)length)` wasn't helping. Even for `Span<T>` it wasn't eliminating bounds checks because the `index` is always coming as a struct property, and the JIT doesn't have enough information to prove it will remain within boundaries. One way to eliminate them is to use `MemoryMarshal.GetArrayDataReference` and pointer arithmetic without any safety checks.

## Benchmarks

I wasn't sure if I should add any additional benchmarks to the existing. They can be found here, and I can port if maintainers agree, that there is need for them. You can find them in a [separate branch](https://github.com/unsafePtr/ZLinq/tree/bench/array-where/sandbox/ArrayWhereBenchmark)

```

BenchmarkDotNet v0.15.4, Windows 11 (10.0.26100.6584/24H2/2024Update/HudsonValley)
13th Gen Intel Core i7-13700KF 3.40GHz, 1 CPU, 24 logical and 16 physical cores
.NET SDK 10.0.100-rc.1.25451.107
  [Host]    : .NET 9.0.9 (9.0.9, 9.0.925.41916), X64 RyuJIT x86-64-v3
  .NET 10.0 : .NET 10.0.0 (10.0.0-rc.1.25451.107, 10.0.25.45207), X64 RyuJIT x86-64-v3

Job=.NET 10.0  Runtime=.NET 10.0  

```
| Method           | Size   | Mean      | Error    | StdDev   | Ratio        | RatioSD | Code Size |
|----------------- |------- |----------:|---------:|---------:|-------------:|--------:|----------:|
| **Current**          | **10000**  |  **45.57 μs** | **0.430 μs** | **0.403 μs** |     **baseline** |        **** |     **272 B** |
| Hoisting         | 10000  |  44.99 μs | 0.268 μs | 0.209 μs | 1.01x faster |   0.01x |     274 B |
| WithOptimization | 10000  |  46.21 μs | 0.560 μs | 0.497 μs | 1.01x slower |   0.01x |     270 B |
|                  |        |           |          |          |              |         |           |
| **Current**          | **100000** | **507.47 μs** | **6.067 μs** | **5.378 μs** |     **baseline** |        **** |     **270 B** |
| Hoisting         | 100000 | 501.08 μs | 1.770 μs | 1.382 μs | 1.01x faster |   0.01x |     272 B |
| WithOptimization | 100000 | 497.03 μs | 4.484 μs | 3.744 μs | 1.02x faster |   0.01x |     268 B |


## Changes

I've changed only `Where`/`Select` for arrays as a proof-of-concept. Theoretically, I could also benchmark cases for `List<T>`,
```cs
var span = CollectionsMarshal.AsSpan(list);
ref var firstElement = ref MemoryMarshal.GetReference(span);