### PR TITLE
feat: Add .NET10 package publishing

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -21,7 +21,7 @@ on:
       framework:
         type: choice
         description: Specify target framework for benchmark
-        default: net9.0
+        default: net10.0
         options:
           - net9.0
           - net10.0
@@ -35,11 +35,12 @@ jobs:
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-
-      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-        if: ${{ inputs.framework == 'net10.0' }}
         with:
-          dotnet-version: 10.0.x
+          dotnet-version: |
+            6.0.x
+            8.0.x
+            9.0.x
+            10.0.x
 
       - run: dotnet build -c Release
 

--- a/.github/workflows/build-debug.yaml
+++ b/.github/workflows/build-debug.yaml
@@ -22,6 +22,12 @@ jobs:
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+        with:
+          dotnet-version: |
+            6.0.x
+            8.0.x
+            9.0.x
+            10.0.x
       - run: dotnet build -c Release
       - run: dotnet test -c Release --no-build
       - run: dotnet build -c Release tests/System.Linq.Tests/System.Linq.Tests.slnx
@@ -60,6 +66,9 @@ jobs:
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+        with:
+          dotnet-version: |
+            10.0.x
       - run: |
           dotnet build -c Release
           dotnet build -c Release tests/System.Linq.Tests/System.Linq.Tests.slnx
@@ -80,9 +89,9 @@ jobs:
           dotnet coverage collect --session-id $sessionId --nologo --settings codecoverage.runsettings --server-mode --background
           try
           {
-            dotnet coverage connect $sessionId --nologo "dotnet test ../ -c Release --framework net9.0 --no-build"
+            dotnet coverage connect $sessionId --nologo "dotnet test ../ -c Release --framework net10.0 --no-build"
 
-            dotnet coverage connect $sessionId --nologo "dotnet test -c Release System.Linq.Tests/System.Linq.Tests.slnx --framework net9.0 --no-build"
+            dotnet coverage connect $sessionId --nologo "dotnet test -c Release System.Linq.Tests/System.Linq.Tests.slnx --framework net10.0 --no-build"
           }
           finally
           {

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -33,6 +33,12 @@ jobs:
     steps:
       - uses: Cysharp/Actions/.github/actions/checkout@main
       - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
+        with:
+          dotnet-version: |
+            6.0.x
+            8.0.x
+            9.0.x
+            10.0.x
       - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
       - run: dotnet test -c Release --no-build
       - run: dotnet pack -c Release -p:Version=${{ inputs.tag }} -o ./publish

--- a/sandbox/Benchmark/Benchmark.csproj
+++ b/sandbox/Benchmark/Benchmark.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net9.0;net8.0</TargetFrameworks>
-    <LangVersion>13</LangVersion>
+    <TargetFrameworks>net10.0;net9.0;net8.0</TargetFrameworks>
+    <LangVersion>14</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -15,10 +15,12 @@
     <DefineConstants>$(DefineConstants);DIAGHUB_ENABLE_TRACE_SYSTEM</DefineConstants>
   </PropertyGroup>
 
-  <!-- Add .NET 10 support if .NET 10 or later version of MSBuild is used. -->
-  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','10.0'))">
-    <TargetFrameworks>net10.0;$(TargetFrameworks)</TargetFrameworks>
+  <!-- Add .NET 11 support if .NET 11 or later version of MSBuild is used. -->
+  <!--
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','11.0'))">
+    <TargetFrameworks>net11.0;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
+  -->
 
   <ItemGroup>
     <PackageReference Include="AndanteSoft.SpanLinq" Version="1.0.1" />

--- a/sandbox/Benchmark/Benchmarks/Net90OptimizedBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/Net90OptimizedBenchmark.cs
@@ -147,3 +147,13 @@ public class Net90OptimizedBenchmark
                      .Sum();
     }
 }
+
+#if !NET10_0_OR_GREATER
+// Workaround code for breaking changes that introduced .NET 10 with LangVersion:14.
+// See: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/csharp-overload-resolution
+file static class ExtensionMethods
+{
+    public static IEnumerable<T> Reverse<T>(this T[] source)
+        => Enumerable.Reverse(source);
+}
+#endif

--- a/sandbox/Benchmark/Benchmarks/OrderTakeBenchmark.cs
+++ b/sandbox/Benchmark/Benchmarks/OrderTakeBenchmark.cs
@@ -21,7 +21,7 @@ public class OrderTakeBenchmark
     {
         var rand = new Random(42);
         array = new int[N];
-        rand.NextBytes(MemoryMarshal.Cast<int, byte>(array));
+        rand.NextBytes(MemoryMarshal.Cast<int, byte>(array).ToArray());
     }
 
     [Benchmark]

--- a/sandbox/Benchmark/Benchmarks/SimdAggregate.cs
+++ b/sandbox/Benchmark/Benchmarks/SimdAggregate.cs
@@ -17,7 +17,7 @@ public class SimdAggregate
     {
         numbers = new int[100000];
         var rand = new Random();
-        rand.NextBytes(MemoryMarshal.Cast<int, byte>(numbers));
+        rand.NextBytes(MemoryMarshal.Cast<int, byte>(numbers).ToArray());
     }
 
     [Benchmark]

--- a/sandbox/Benchmark/Program.cs
+++ b/sandbox/Benchmark/Program.cs
@@ -9,7 +9,6 @@ using Cathei.LinqGen;
 using Kokuban;
 using Microsoft.DiagnosticsHub;
 using Perfolizer.Horology;
-using SpanLinq;
 using System.Diagnostics;
 using ZLinq;
 using ZLinq.Internal;

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);CS8002</NoWarn>

--- a/sandbox/ConsoleAppNativeAOT/ConsoleAppNativeAOT.csproj
+++ b/sandbox/ConsoleAppNativeAOT/ConsoleAppNativeAOT.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PublishTrimmed>true</PublishTrimmed>

--- a/src/FileGen/FileGen.csproj
+++ b/src/FileGen/FileGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);CS8002</NoWarn>

--- a/src/ZLinq.DropInGenerator/ZLinq.DropInGenerator.csproj
+++ b/src/ZLinq.DropInGenerator/ZLinq.DropInGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalyzerLanguage>cs</AnalyzerLanguage>
     <Nullable>enable</Nullable>

--- a/src/ZLinq.FileSystem/ZLinq.FileSystem.csproj
+++ b/src/ZLinq.FileSystem/ZLinq.FileSystem.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
 
     <!-- NuGet Packaging -->

--- a/src/ZLinq.Godot/ZLinq.Godot.csproj
+++ b/src/ZLinq.Godot/ZLinq.Godot.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);CS8002</NoWarn>

--- a/src/ZLinq.Json/ZLinq.Json.csproj
+++ b/src/ZLinq.Json/ZLinq.Json.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <NoWarn>$(NoWarn);CS8002</NoWarn>
 
     <!-- NuGet Packaging -->

--- a/src/ZLinq/ZLinq.csproj
+++ b/src/ZLinq/ZLinq.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0;net9.0;net10.0</TargetFrameworks>
     <RootNamespace>ZLinq</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <NoWarn>$(NoWarn);1701;1702;9124;0436</NoWarn>
-    <LangVersion>13</LangVersion>
+    <LangVersion>14</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- NuGet Packaging -->
@@ -20,10 +20,12 @@
     <IsTrimmable>true</IsTrimmable>
   </PropertyGroup>
 
-  <!-- Add .NET 10 support if .NET 10 or later version of MSBuild is used. -->
-  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','10.0'))">
-    <TargetFrameworks>$(TargetFrameworks);net10.0</TargetFrameworks>
+  <!-- Add .NET 11 support if .NET 11 or later version of MSBuild is used. -->
+  <!--
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','11.0'))">
+    <TargetFrameworks>$(TargetFrameworks);net11.0</TargetFrameworks>
   </PropertyGroup>
+  -->
 
   <PropertyGroup Condition="$(TargetFramework.StartsWith(`netstandard`))">
     <ProduceReferenceAssembly>true</ProduceReferenceAssembly>

--- a/tests/System.Linq.Tests/System.Linq.Tests.csproj
+++ b/tests/System.Linq.Tests/System.Linq.Tests.csproj
@@ -5,8 +5,8 @@
     <RootNamespace>ZLinq.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net9.0</TargetFrameworks>
-    <LangVersion>13</LangVersion>
+    <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
+    <LangVersion>14</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 
     <!-- Use custom root namespace -->
@@ -20,10 +20,12 @@
     <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
-  <!-- Add .NET 10 support if .NET 10 or later version of MSBuild is used. -->
-  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','10.0'))">
-    <TargetFrameworks>net10.0;$(TargetFrameworks)</TargetFrameworks>
+  <!-- Add .NET 11 support if .NET 11 or later version of MSBuild is used. -->
+  <!--
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','11.0'))">
+    <TargetFrameworks>$(TargetFrameworks);net11.0</TargetFrameworks>
   </PropertyGroup>
+  -->
 
   <ItemGroup>
     <None Remove="$(MSBuildThisFileName).slnx" />

--- a/tests/System.Linq.Tests/Tests/ZLinq/RepeatTests.cs
+++ b/tests/System.Linq.Tests/Tests/ZLinq/RepeatTests.cs
@@ -281,7 +281,7 @@ namespace ZLinq.Tests
                 list.CopyTo(actual, 1);
                 Assert.Equal(0, actual[0]);
                 Assert.Equal(0, actual[^1]);
-                AssertExtensions.SequenceEqual(expected, actual.AsSpan(1, expected.Length));
+                AssertExtensions.SequenceEqual(expected.AsSpan(), actual.AsSpan(1, expected.Length));
             }
         }
     }

--- a/tests/ZLinq.Tests/Linq/OrderBySkipTakeTest.cs
+++ b/tests/ZLinq.Tests/Linq/OrderBySkipTakeTest.cs
@@ -207,7 +207,7 @@ public class OrderBySkipTakeTest
         for (int i = 100; i < 5000; i++)
         {
             var data = new int[i];
-            rand.NextBytes(MemoryMarshal.Cast<int, byte>(data));
+            rand.NextBytes(MemoryMarshal.Cast<int, byte>(data).ToArray());
 
             var skip = rand.Next(0, i);
             var take = rand.Next(0, i);

--- a/tests/ZLinq.Tests/Linq/ReverseTest.cs
+++ b/tests/ZLinq.Tests/Linq/ReverseTest.cs
@@ -219,3 +219,13 @@ public class ReverseTest
         reversed.Dispose();
     }
 }
+
+#if !NET10_0_OR_GREATER
+// Workaround code for breaking changes that introduced .NET 10 with LangVersion:14.
+// See: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/csharp-overload-resolution
+file static class ExtensionMethods
+{
+    public static IEnumerable<T> Reverse<T>(this T[] source)
+        => Enumerable.Reverse(source);
+}
+#endif

--- a/tests/ZLinq.Tests/ZLinq.Tests.csproj
+++ b/tests/ZLinq.Tests/ZLinq.Tests.csproj
@@ -4,8 +4,8 @@
     <RootNamespace>ZLinq.Tests</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <TargetFrameworks>net6.0;net8.0;net9.0</TargetFrameworks>
-    <LangVersion>13</LangVersion>
+    <TargetFrameworks>net6.0;net8.0;net9.0;net10.0</TargetFrameworks>
+    <LangVersion>14</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <NoWarn>$(NoWarn);CS8002;CS0618</NoWarn>
 
@@ -21,10 +21,12 @@
     <TargetFrameworks>$(TargetFrameworks);net48</TargetFrameworks>
   </PropertyGroup>
 
-  <!-- Add .NET 10 support if .NET 10 or later version of MSBuild is used. -->
-  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','10.0'))">
-    <TargetFrameworks>net10.0;$(TargetFrameworks)</TargetFrameworks>
+  <!-- Add .NET 11 support if .NET 11 or later version of MSBuild is used. -->
+  <!--
+  <PropertyGroup Condition="$([MSBuild]::VersionGreaterThanOrEquals('$(NETCoreAppMaximumVersion)','11.0'))">
+    <TargetFrameworks>$(TargetFrameworks);net11.0</TargetFrameworks>
   </PropertyGroup>
+  -->
 
   <!-- Disable EOL warning for net6.0 -->
   <PropertyGroup Condition="'$(TargetFramework)' == 'net6.0'">


### PR DESCRIPTION
This PR intended to add .NET 10 package publishing (Currently RC2)

#### What's changed in this PR
- Add `net10.0` to TargetFrameworks. (Previously it's enabled only when .NET 10 SDK is installed)
- Update LangVersion to `14`
- Modify base TargetFramework from `net8.0` to `net10.0`
- Modify CI workflows to install target SDKs explicitly.
- Modify code that cause errors when using LangVersion to `14` (That is caused by [Breaking Changes: C# 14 overload resolution with span parameters](https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/10.0/csharp-overload-resolution)
  - For non-perf related code. Simply add ToArray/AsSpan to resolve overload.
  - For `Reverse` overload issue. Add file-local extension method that similar to [`Reverse` overload that introduced by .NET 10](`https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.reverse`) 
