### PR TITLE
Fix double dispose in OrderBy, Shuffle, Shuffle.SkipTake

### DIFF
--- a/src/ZLinq/Linq/OrderBy.cs
+++ b/src/ZLinq/Linq/OrderBy.cs
@@ -269,6 +269,14 @@ namespace ZLinq.Linq
         public void Dispose()
         {
             buffer?.Dispose();
+
+            if (buffer != null)
+            {
+                // source already disposed by enumeration in the InitBuffer()
+                // or the (destination.Length == 1) branch in TryCopyTo
+                return;
+            }
+
             source.Dispose();
         }
 

--- a/src/ZLinq/Linq/Shuffle.SkipTake.cs
+++ b/src/ZLinq/Linq/Shuffle.SkipTake.cs
@@ -123,6 +123,13 @@ namespace ZLinq.Linq
         public void Dispose()
         {
             buffer?.Dispose();
+
+            if (buffer != null)
+            {
+                // source already disposed by enumeration in the InitBuffer()
+                return;
+            }
+
             source.Dispose();
         }
 

--- a/src/ZLinq/Linq/Shuffle.cs
+++ b/src/ZLinq/Linq/Shuffle.cs
@@ -87,6 +87,13 @@ namespace ZLinq.Linq
         public void Dispose()
         {
             buffer?.Dispose();
+
+            if (buffer != null)
+            {
+                // source already disposed by enumeration in the InitBuffer()
+                return;
+            }
+
             source.Dispose();
         }
 


### PR DESCRIPTION
Hi, this is a followup to #192 - I came across the same problem in `OrderBy`, and it looks like `Shuffle` and `Shuffle.SkipTake` are also affected. I applied pretty much the same fix as before. I will test other operators when I have some time.