### PR TITLE
Add the "Unity" suffix to the Unity extension package.

### DIFF
--- a/src/ZLinq.Unity/Assets/ZLinq.Unity/package.json
+++ b/src/ZLinq.Unity/Assets/ZLinq.Unity/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.cysharp.zlinq",
-    "displayName": "ZLinq",
+    "displayName": "ZLinq.Unity",
     "author": { "name": "Cysharp, Inc.", "url": "https://cysharp.co.jp/en/" },
     "version": "1.5.6",
     "unity": "2021.3",


### PR DESCRIPTION
Distinguish between the core package and the Unity extension package.